### PR TITLE
Download test data before executing `mvn test`

### DIFF
--- a/data/readme.txt
+++ b/data/readme.txt
@@ -1,1 +1,0 @@
-Please execute retrieve_data.sh or retrieve_data.bat

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,11 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>jp.preferred</groupId>
-  <artifactId>menoh-api</artifactId>
+  <artifactId>menoh</artifactId>
   <version>1.0.0-SNAPSHOT</version>
 
-  <name>Menoh JVM API</name>
-  <!-- FIXME change it to the project's website -->
-  <url>http://www.example.com</url>
+  <name>Menoh Java API</name>
+  <url>https://github.com/pfnet-research/menoh-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -117,6 +116,53 @@
           <xmlOutputDirectory>target/site/findbugs</xmlOutputDirectory>
           <findbugsXmlOutputDirectory>target/site/findbugs</findbugsXmlOutputDirectory>
         </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>wagon-maven-plugin</artifactId>
+        <version>2.0.0</version>
+        <executions>
+          <execution>
+            <id>download-vgg16-onnx</id>
+            <phase>process-test-resources</phase>
+            <goals>
+              <goal>download-single</goal>
+            </goals>
+            <configuration>
+              <url>https://www.dropbox.com</url>
+              <fromFile>s/bjfn9kehukpbmcm/VGG16.onnx?dl=1</fromFile>
+              <toFile>${project.build.testOutputDirectory}/data/VGG16.onnx</toFile>
+              <skipIfExists>true</skipIfExists>
+            </configuration>
+          </execution>
+          <execution>
+            <id>download-synset-words-txt</id>
+            <phase>process-test-resources</phase>
+            <goals>
+              <goal>download-single</goal>
+            </goals>
+            <configuration>
+              <url>https://raw.githubusercontent.com</url>
+              <fromFile>HoldenCaulfieldRye/caffe/master/data/ilsvrc12/synset_words.txt</fromFile>
+              <toFile>${project.build.testOutputDirectory}/data/synset_words.txt</toFile>
+              <skipIfExists>true</skipIfExists>
+            </configuration>
+          </execution>
+          <execution>
+            <id>download-light-sussex-hen-jpg</id>
+            <phase>process-test-resources</phase>
+            <goals>
+              <goal>download-single</goal>
+            </goals>
+            <configuration>
+              <url>https://upload.wikimedia.org</url>
+              <fromFile>wikipedia/commons/5/54/Light_sussex_hen.jpg</fromFile>
+              <toFile>${project.build.testOutputDirectory}/data/Light_sussex_hen.jpg</toFile>
+              <skipIfExists>true</skipIfExists>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/retrieve_data.bat
+++ b/retrieve_data.bat
@@ -1,3 +1,0 @@
-bitsadmin.exe /TRANSFER get https://www.dropbox.com/s/bjfn9kehukpbmcm/VGG16.onnx?dl=1 %~dp0\data\VGG16.onnx
-bitsadmin.exe /TRANSFER get https://raw.githubusercontent.com/HoldenCaulfieldRye/caffe/master/data/ilsvrc12/synset_words.txt %~dp0\data\synset_words.txt
-bitsadmin.exe /TRANSFER get https://upload.wikimedia.org/wikipedia/commons/5/54/Light_sussex_hen.jpg %~dp0\data\Light_sussex_hen.jpg

--- a/retrieve_data.sh
+++ b/retrieve_data.sh
@@ -1,3 +1,0 @@
-wget https://www.dropbox.com/s/bjfn9kehukpbmcm/VGG16.onnx?dl=1 -O ./data/VGG16.onnx
-wget https://raw.githubusercontent.com/HoldenCaulfieldRye/caffe/master/data/ilsvrc12/synset_words.txt -O ./data/synset_words.txt
-wget https://upload.wikimedia.org/wikipedia/commons/5/54/Light_sussex_hen.jpg -O ./data/Light_sussex_hen.jpg

--- a/src/main/java/jp/preferred/menoh/MenohException.java
+++ b/src/main/java/jp/preferred/menoh/MenohException.java
@@ -1,5 +1,7 @@
 package jp.preferred.menoh;
 
+import java.util.Locale;
+
 public class MenohException extends RuntimeException {
     private final ErrorCode errorCode;
 
@@ -45,7 +47,9 @@ public class MenohException extends RuntimeException {
             final String errorMessage = MenohNative.INSTANCE.menoh_get_last_error_message();
             try {
                 ErrorCode ec = ErrorCode.valueOf(errorCode);
-                throw new MenohException(ec, String.format("%s: %s", ec.toString().toLowerCase(), errorMessage));
+                throw new MenohException(
+                        ec,
+                        String.format("%s: %s", ec.toString().toLowerCase(Locale.ENGLISH), errorMessage));
             } catch (MenohException e) {
                 // jp.preferred.menoh.ErrorCode.valueOf() throws MenohException if the error code is
                 // undefined

--- a/src/test/java/jp/preferred/menoh/AppTest.java
+++ b/src/test/java/jp/preferred/menoh/AppTest.java
@@ -40,9 +40,9 @@ public class AppTest {
         int height = 224;
         int width = 224;
 
-        String inputImagePath = "Light_sussex_hen.jpg";
-        String onnxModelPath = "VGG16.onnx";
-        String synsetWordsPath = "synset_words.txt";
+        final String inputImagePath = getClass().getResource("/data/Light_sussex_hen.jpg").getFile();
+        final String onnxModelPath = getClass().getResource("/data/VGG16.onnx").getFile();
+        final String synsetWordsPath = getClass().getResource("/data/synset_words.txt").getFile();
 
         BufferedImage image = ImageIO.read(new File(inputImagePath));
 

--- a/src/test/java/jp/preferred/menoh/AppTest.java
+++ b/src/test/java/jp/preferred/menoh/AppTest.java
@@ -12,6 +12,9 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -40,9 +43,9 @@ public class AppTest {
         int height = 224;
         int width = 224;
 
-        final String inputImagePath = getClass().getResource("/data/Light_sussex_hen.jpg").getFile();
-        final String onnxModelPath = getClass().getResource("/data/VGG16.onnx").getFile();
-        final String synsetWordsPath = getClass().getResource("/data/synset_words.txt").getFile();
+        final String inputImagePath = asFilePath(getClass().getResource("/data/Light_sussex_hen.jpg"));
+        final String onnxModelPath = asFilePath(getClass().getResource("/data/VGG16.onnx"));
+        final String synsetWordsPath = asFilePath(getClass().getResource("/data/synset_words.txt"));
 
         BufferedImage image = ImageIO.read(new File(inputImagePath));
 
@@ -110,6 +113,11 @@ public class AppTest {
                 System.out.println(ki + " " + scoreArray[ki] + "  categories are" + categories[ki]);
             }
         }
+    }
+
+    private static String asFilePath(URL url) throws IOException, URISyntaxException {
+        // ref. https://stackoverflow.com/a/17870390/1014818
+        return Paths.get(url.toURI()).toFile().getCanonicalPath();
     }
 
     private static BufferedImage resizeImage(BufferedImage image, int width, int height) {


### PR DESCRIPTION
Download test data (`VGG16.onnx`, `synset_words.txt` and `Light_sussex_hen.jpg`) before executing `mvn test` by using `wagon-maven-plugin` in `pom.xml`. It will run in any platform including Windows.

```
$ mvn clean test
[INFO] Scanning for projects...
[INFO] 
[INFO] -------------------------< jp.preferred:menoh >-------------------------
[INFO] Building Menoh Java API 1.0.0-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-clean-plugin:3.0.0:clean (default-clean) @ menoh ---
[INFO] Deleting /home/okapies/workspace/menoh-java/target

...

[INFO] --- wagon-maven-plugin:2.0.0:download-single (download-vgg16-onnx) @ menoh ---
[INFO] Downloading: https://www.dropbox.com/s/bjfn9kehukpbmcm/VGG16.onnx?dl=1 to /home/okapies/workspace/menoh-java/target/test-classes/data/VGG16.onnx
[INFO] 
[INFO] --- wagon-maven-plugin:2.0.0:download-single (download-synset-words-txt) @ menoh ---
[INFO] Downloading: https://raw.githubusercontent.com/HoldenCaulfieldRye/caffe/master/data/ilsvrc12/synset_words.txt to /home/okapies/workspace/menoh-java/target/test-classes/data/synset_words.txt
[INFO] 
[INFO] --- wagon-maven-plugin:2.0.0:download-single (download-light-sussex-hen-jpg) @ menoh ---
[INFO] Downloading: https://upload.wikimedia.org/wikipedia/commons/5/54/Light_sussex_hen.jpg to /home/okapies/workspace/menoh-java/target/test-classes/data/Light_sussex_hen.jpg
[INFO] 
[INFO] --- maven-compiler-plugin:3.7.0:testCompile (default-testCompile) @ menoh ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 1 source file to /home/okapies/workspace/menoh-java/target/test-classes
[INFO] 
[INFO] --- maven-surefire-plugin:2.22.0:test (default-test) @ menoh ---
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running jp.preferred.menoh.AppTest
Working Directory = /home/okapies/workspace/menoh-java
-21.302792 -34.792274 -11.198693 23.983116 0.8887066 -6.290651 -26.45818 -24.885696 -4.925243 14.338675 
top 5  categories are
8 0.9705545  categories aren01514859 hen
7 0.028219773  categories aren01514668 cock
86 9.522993E-4  categories aren01807496 partridge
82 1.6639252E-4  categories aren01797886 ruffed grouse, partridge, Bonasa umbellus
97 2.0030011E-5  categories aren01847000 drake
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.278 s - in jp.preferred.menoh.AppTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0

...

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 58.458 s
[INFO] Finished at: 2018-07-25T15:26:39+09:00
[INFO] ------------------------------------------------------------------------
```