### PR TITLE
Make `Variable#buffer()` return `ByteBuffer` instead of `Pointer`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,12 @@
       <version>4.5.1</version>
     </dependency>
     <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>findbugs-annotations</artifactId>
+      <version>3.0.1</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.11</version>

--- a/src/main/java/jp/preferred/menoh/DType.java
+++ b/src/main/java/jp/preferred/menoh/DType.java
@@ -16,6 +16,16 @@ public enum DType {
         return id;
     }
 
+    public int size() throws MenohException {
+        switch (this) {
+            case Float:
+                return 4;
+            default:
+                throw new MenohException(
+                        ErrorCode.UNDEFINED, String.format("the size of dtype is unknown: %d", id));
+        }
+    }
+
     public static DType valueOf(int value) throws MenohException {
         if (0 <= value && value < values.length) {
             DType ret = values[value];

--- a/src/main/java/jp/preferred/menoh/Model.java
+++ b/src/main/java/jp/preferred/menoh/Model.java
@@ -48,9 +48,7 @@ public class Model implements AutoCloseable {
         PointerByReference buffer = new PointerByReference();
         checkError(MenohNative.INSTANCE.menoh_model_get_variable_buffer_handle(handle, name, buffer));
 
-        Variable ret = new Variable(DType.valueOf(dtype.getValue()), dims, buffer.getValue());
-
-        return ret;
+        return new Variable(DType.valueOf(dtype.getValue()), dims, buffer.getValue());
     }
 
     public void run() throws MenohException {

--- a/src/main/java/jp/preferred/menoh/Variable.java
+++ b/src/main/java/jp/preferred/menoh/Variable.java
@@ -2,6 +2,8 @@ package jp.preferred.menoh;
 
 import com.sun.jna.Pointer;
 
+import java.nio.ByteBuffer;
+
 public class Variable {
     private final DType dtype;
     private final int[] dims;
@@ -13,15 +15,32 @@ public class Variable {
         this.bufferHandle = bufferHandle;
     }
 
-    DType dtype() {
+    public DType dtype() {
         return this.dtype;
     }
 
-    int[] dims() {
-        return this.dims;
+    public int[] dims() {
+        if (dims != null) {
+            return this.dims.clone();
+        } else {
+            return new int[0];
+        }
     }
 
-    Pointer bufferHandle() {
-        return this.bufferHandle;
+    public ByteBuffer buffer() throws MenohException {
+        final long offset = 0;
+        final long elementSize = dtype.size();
+
+        long length;
+        if (dims.length > 0) {
+            length = 1;
+            for (int d : dims) {
+                length *= d;
+            }
+        } else {
+            length = 0;
+        }
+
+        return this.bufferHandle.getByteBuffer(offset, elementSize * length);
     }
 }

--- a/src/main/java/jp/preferred/menoh/VariableProfile.java
+++ b/src/main/java/jp/preferred/menoh/VariableProfile.java
@@ -9,11 +9,15 @@ public class VariableProfile {
         this.dims = dims;
     }
 
-    DType dtype() {
+    public DType dtype() {
         return this.dtype;
     }
 
-    int[] dims() {
-        return this.dims;
+    public int[] dims() {
+        if (dims != null) {
+            return this.dims.clone();
+        } else {
+            return new int[0];
+        }
     }
 }


### PR DESCRIPTION
Use NIO's `ByteBuffer` (which is a direct buffer) instead of JNA's `Pointer` to hide implementation details.