### PR TITLE
Add unit tests (part 4) and some improvements

### DIFF
--- a/menoh/src/main/java/jp/preferred/menoh/Model.java
+++ b/menoh/src/main/java/jp/preferred/menoh/Model.java
@@ -6,6 +6,9 @@ import com.sun.jna.Pointer;
 import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.PointerByReference;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * It is created by {@link ModelBuilder}.
  */
@@ -13,14 +16,24 @@ public class Model implements AutoCloseable {
     private Pointer handle;
 
     /**
+     * A reference to the pointers to prevent them from getting garbage collected.
+     */
+    private final List<Pointer> attachedBuffers;
+
+    /**
      * @param handle a pointer to a native <code>menoh_model</code>
      */
-    Model(Pointer handle) {
+    Model(Pointer handle, List<Pointer> attachedBuffers) {
         this.handle = handle;
+        this.attachedBuffers = attachedBuffers;
     }
 
     Pointer nativeHandle() {
         return this.handle;
+    }
+
+    List<Pointer> attachedBuffers() {
+        return this.attachedBuffers;
     }
 
     @Override
@@ -29,6 +42,7 @@ public class Model implements AutoCloseable {
             if (handle != Pointer.NULL) {
                 MenohNative.INSTANCE.menoh_delete_model(handle);
                 handle = Pointer.NULL;
+                attachedBuffers.clear();
             }
         }
     }

--- a/menoh/src/main/java/jp/preferred/menoh/ModelBuilder.java
+++ b/menoh/src/main/java/jp/preferred/menoh/ModelBuilder.java
@@ -1,16 +1,23 @@
 package jp.preferred.menoh;
 
 import static jp.preferred.menoh.BufferUtils.copyToNativeMemory;
-import static jp.preferred.menoh.BufferUtils.toDirectByteBuffer;
 import static jp.preferred.menoh.MenohException.checkError;
 
 import com.sun.jna.Pointer;
 import com.sun.jna.ptr.PointerByReference;
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.List;
 
 public class ModelBuilder implements AutoCloseable {
     private Pointer handle;
+
+    /**
+     * A reference to the pointers to prevent them from getting garbage collected.
+     */
+    private final List<Pointer> attachedBuffers = new ArrayList<>();
 
     private ModelBuilder(Pointer handle) {
         this.handle = handle;
@@ -20,16 +27,27 @@ public class ModelBuilder implements AutoCloseable {
         return this.handle;
     }
 
+    List<Pointer> attachedBuffers() {
+        return this.attachedBuffers;
+    }
+
+    /**
+     * Release the model builder.
+     */
     @Override
     public void close() {
         synchronized (this) {
             if (handle != Pointer.NULL) {
                 MenohNative.INSTANCE.menoh_delete_model_builder(handle);
                 handle = Pointer.NULL;
+                attachedBuffers.clear();
             }
         }
     }
 
+    /**
+     * Make a {@link ModelBuilder} which can <code>attach()</code> a buffer to a variable of the model.
+     */
     public static ModelBuilder make(VariableProfileTable vpt) throws MenohException {
         final PointerByReference ref = new PointerByReference();
         checkError(MenohNative.INSTANCE.menoh_make_model_builder(vpt.nativeHandle(), ref));
@@ -37,25 +55,66 @@ public class ModelBuilder implements AutoCloseable {
         return new ModelBuilder(ref.getValue());
     }
 
+    /**
+     * <p>Attach a buffer to the specified variable. It copies the content of the buffer to an allocated memory
+     * in the native heap ranging from <code>position()</code> to <code>(limit() - 1)</code> without changing them,
+     * except for a direct buffer.</p>
+     *
+     * <p>Note that the <code>order()</code> of the buffer should be {@link ByteOrder#nativeOrder()} because
+     * the native byte order of your platform may differ from JVM.</p>
+     *
+     * @param buffer the byte buffer from which to copy
+     */
+    public void attach(String variableName, ByteBuffer buffer) throws MenohException {
+        final Pointer bufferHandle = copyToNativeMemory(buffer);
+        synchronized (this) {
+            attachedBuffers.add(bufferHandle);
+        }
+
+        attachImpl(variableName, bufferHandle);
+    }
+
+    /**
+     * <p>Attach an array to the specified variable. It copies the content of the array to an allocated memory
+     * in the native heap.</p>
+     *
+     * @param values the byte buffer from which to copy
+     */
     public void attach(String variableName, float[] values) throws MenohException {
         attach(variableName, values, 0, values.length);
     }
 
+    /**
+     * <p>Attach an array to the specified variable. It copies the content of the array to an allocated memory
+     * in the native heap ranging from <code>offset</code> to <code>(offset + length - 1)</code>.</p>
+     *
+     * @param values the byte buffer from which to copy
+     */
     public void attach(String variableName, float[] values, int offset, int length) throws MenohException {
-        attach(variableName, toDirectByteBuffer(values, offset, length));
+        final Pointer bufferHandle = copyToNativeMemory(values, offset, length);
+        synchronized (this) {
+            attachedBuffers.add(bufferHandle);
+        }
+
+        attachImpl(variableName, bufferHandle);
     }
 
-    public void attach(String variableName, ByteBuffer buffer) throws MenohException {
-        final Pointer bufferHandle = copyToNativeMemory(buffer);
-        checkError(MenohNative.INSTANCE.menoh_model_builder_attach_external_buffer(handle, variableName, bufferHandle));
+    private void attachImpl(String variableName, Pointer bufferHandle) throws MenohException {
+        checkError(MenohNative.INSTANCE.menoh_model_builder_attach_external_buffer(
+                handle, variableName, bufferHandle));
     }
 
-    public Model build(ModelData modelData, String backendName, String backendConfig)
-            throws MenohException {
+    /**
+     * Build a {@link Model} to <code>run()</code> based on a {@link ModelData} and the attached buffers
+     * by using the specified backend.
+     */
+    public Model build(ModelData modelData, String backendName, String backendConfig) throws MenohException {
         final PointerByReference ref = new PointerByReference();
         checkError(MenohNative.INSTANCE.menoh_build_model(
                 this.handle, modelData.nativeHandle(), backendName, backendConfig, ref));
 
-        return new Model(ref.getValue());
+        synchronized (this) {
+            return new Model(ref.getValue(), new ArrayList<>(this.attachedBuffers));
+        }
     }
 }

--- a/menoh/src/test/java/jp/preferred/menoh/BufferUtilsTest.java
+++ b/menoh/src/test/java/jp/preferred/menoh/BufferUtilsTest.java
@@ -1,0 +1,222 @@
+package jp.preferred.menoh;
+
+// CHECKSTYLE:OFF
+import static jp.preferred.menoh.TestUtils.*;
+import static org.junit.jupiter.api.Assertions.*;
+// CHECKSTYLE:ON
+
+import com.sun.jna.Pointer;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import org.junit.jupiter.api.Test;
+
+public class BufferUtilsTest {
+    @Test
+    public void copyDirectBufferToNativeMemory() {
+        final byte[] bytes = new byte[] {0, 1, 2, 3, 4, 5, 6, 7};
+
+        final ByteBuffer buf = ByteBuffer.allocateDirect(bytes.length);
+        buf.put(bytes).rewind();
+        assertEquals(8, buf.remaining());
+
+        final Pointer ptr = BufferUtils.copyToNativeMemory(buf);
+        assertNotNull(ptr);
+        assertArrayEquals(bytes, ptr.getByteArray(0, bytes.length));
+        assertAll("buffer's state",
+                () -> assertEquals(0, buf.position()),
+                () -> assertEquals(8, buf.limit())
+        );
+    }
+
+    @Test
+    public void copySlicedDirectBufferToNativeMemory() {
+        final byte[] bytes = new byte[] {0, 1, 2, 3, 4, 5, 6, 7};
+        final byte[] slicedBytes = new byte[] {2, 3, 4, 5};
+
+        final ByteBuffer buf = ByteBuffer.allocateDirect(bytes.length);
+        buf.put(bytes).rewind();
+
+        // slice 4 bytes
+        buf.position(2).limit(6);
+        assertEquals(4, buf.remaining());
+
+        final Pointer ptr = BufferUtils.copyToNativeMemory(buf);
+        assertNotNull(ptr);
+        assertArrayEquals(slicedBytes, ptr.getByteArray(0, slicedBytes.length));
+        assertAll("buffer's state",
+                () -> assertEquals(2, buf.position()),
+                () -> assertEquals(6, buf.limit())
+        );
+    }
+
+    @Test
+    public void copyEmptyDirectBufferToNativeMemory() {
+        final ByteBuffer buf = ByteBuffer.allocateDirect(0);
+        assertEquals(0, buf.remaining());
+
+        final Pointer ptr = BufferUtils.copyToNativeMemory(buf);
+        assertNotNull(ptr);
+        assertAll("buffer's state",
+                () -> assertEquals(0, buf.position()),
+                () -> assertEquals(0, buf.limit())
+        );
+    }
+
+    @Test
+    public void copyArrayBackedBufferToNativeMemory() {
+        final byte[] bytes = new byte[] {0, 1, 2, 3, 4, 5, 6, 7};
+
+        final ByteBuffer buf = ByteBuffer.wrap(bytes);
+        assertEquals(8, buf.remaining());
+
+        final Pointer ptr = BufferUtils.copyToNativeMemory(buf);
+        assertNotNull(ptr);
+        assertArrayEquals(bytes, ptr.getByteArray(0, bytes.length));
+        assertAll("buffer's state",
+                () -> assertEquals(0, buf.position()),
+                () -> assertEquals(8, buf.limit())
+        );
+    }
+
+    @Test
+    public void copySlicedArrayBackedBufferToNativeMemory() {
+        final byte[] bytes = new byte[] {0, 1, 2, 3, 4, 5, 6, 7};
+        final byte[] slicedBytes = new byte[] {2, 3, 4, 5};
+
+        final ByteBuffer buf = ByteBuffer.wrap(bytes, 1, 6).slice();
+        assertAll("non-zero array offset",
+                () -> assertEquals(1, buf.arrayOffset()),
+                () -> assertEquals(0, buf.position()),
+                () -> assertEquals(6, buf.limit())
+        );
+
+        // slice 4 bytes
+        buf.position(1).limit(5);
+        assertEquals(4, buf.remaining());
+
+        final Pointer ptr = BufferUtils.copyToNativeMemory(buf);
+        assertNotNull(ptr);
+        assertArrayEquals(slicedBytes, ptr.getByteArray(0, slicedBytes.length));
+        assertAll("buffer's state",
+                () -> assertEquals(1, buf.position()),
+                () -> assertEquals(5, buf.limit())
+        );
+    }
+
+    @Test
+    public void copyReadOnlyBufferToNativeMemory() {
+        final byte[] bytes = new byte[] {0, 1, 2, 3, 4, 5, 6, 7};
+
+        final ByteBuffer buf = ByteBuffer.wrap(bytes).asReadOnlyBuffer();
+        assertEquals(8, buf.remaining());
+
+        final Pointer ptr = BufferUtils.copyToNativeMemory(buf);
+        assertNotNull(ptr);
+        assertArrayEquals(bytes, ptr.getByteArray(0, bytes.length));
+        assertAll("buffer's state",
+                () -> assertEquals(0, buf.position()),
+                () -> assertEquals(8, buf.limit())
+        );
+    }
+
+    @Test
+    public void copySlicedReadOnlyBufferToNativeMemory() {
+        final byte[] bytes = new byte[] {0, 1, 2, 3, 4, 5, 6, 7};
+        final byte[] slicedBytes = new byte[] {2, 3, 4, 5};
+
+        final ByteBuffer buf = ByteBuffer.wrap(bytes).asReadOnlyBuffer();
+
+        // slice 4 bytes
+        buf.position(2).limit(6);
+        assertEquals(4, buf.remaining());
+
+        final Pointer ptr = BufferUtils.copyToNativeMemory(buf);
+        assertNotNull(ptr);
+        assertArrayEquals(slicedBytes, ptr.getByteArray(0, slicedBytes.length));
+        assertAll("buffer's state",
+                () -> assertEquals(2, buf.position()),
+                () -> assertEquals(6, buf.limit())
+        );
+    }
+
+    @Test
+    public void copyFloatArrayToNativeMemory() {
+        final float[] values = new float[] {0f, 1f, 2f, 3f};
+        final ByteBuffer valuesBuf = ByteBuffer.allocate(values.length * 4).order(ByteOrder.nativeOrder());
+        valuesBuf.asFloatBuffer().put(values);
+        final int offset = 0;
+        final int length = values.length;
+
+        final Pointer ptr = BufferUtils.copyToNativeMemory(values, offset, length);
+        assertNotNull(ptr);
+        assertAll("copied values in native memory",
+                () -> assertArrayEquals(values, ptr.getFloatArray(0, length)),
+                // check the byte order
+                () -> assertArrayEquals(valuesBuf.array(), ptr.getByteArray(0, length * 4))
+        );
+    }
+
+    @Test
+    public void copySlicedFloatArrayToNativeMemory() {
+        final float[] values = new float[] {0f, 1f, 2f, 3f};
+        final float[] slicedValues = new float[] {1f, 2f};
+        final ByteBuffer slicedValuesBuf = ByteBuffer.allocate(slicedValues.length * 4).order(ByteOrder.nativeOrder());
+        slicedValuesBuf.asFloatBuffer().put(slicedValues);
+        final int offset = 1;
+        final int length = slicedValues.length;
+
+        // slice 2 elements (8 bytes)
+        final Pointer ptr = BufferUtils.copyToNativeMemory(values, offset, length);
+        assertNotNull(ptr);
+        assertAll("copied values in native memory",
+                () -> assertArrayEquals(slicedValues, ptr.getFloatArray(0, length)),
+                // check the byte order
+                () -> assertArrayEquals(slicedValuesBuf.array(), ptr.getByteArray(0, length * 4))
+        );
+    }
+
+    @Test
+    public void copyEmptyFloatArrayToNativeMemory() {
+        final float[] values = new float[] {}; // test case
+        final int offset = 0;
+        final int length = values.length;
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> BufferUtils.copyToNativeMemory(values, offset, length));
+    }
+
+    @Test
+    public void copyNullFloatArrayToNativeMemory() {
+        final float[] values = null; // test case
+        final int offset = 0;
+        final int length = 0;
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> BufferUtils.copyToNativeMemory(values, offset, length));
+    }
+
+    @Test
+    public void copyNegativeOffsetFloatArrayToNativeMemory() {
+        final float[] values = new float[] {0f, 1f, 2f, 3f};
+        final int offset = -1; // test case
+        final int length = values.length;
+
+        assertThrows(
+                ArrayIndexOutOfBoundsException.class,
+                () -> BufferUtils.copyToNativeMemory(values, offset, length));
+    }
+
+    @Test
+    public void copyNegativeLengthFloatArrayToNativeMemory() {
+        final float[] values = new float[] {0f, 1f, 2f, 3f};
+        final int offset = 0;
+        final int length = -1; // test case
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> BufferUtils.copyToNativeMemory(values, offset, length));
+    }
+}

--- a/menoh/src/test/java/jp/preferred/menoh/ModelDataTest.java
+++ b/menoh/src/test/java/jp/preferred/menoh/ModelDataTest.java
@@ -18,23 +18,18 @@ public class ModelDataTest {
     }
 
     @Test
-    public void closeModelDataIsIdempotent() throws Exception {
+    public void closeModelData() throws Exception {
         final String path = getResourceFilePath("models/and_op.onnx");
 
-        ModelData modelData = null;
+        final ModelData modelData = ModelData.makeFromOnnx(path);
         try {
-            modelData = ModelData.makeFromOnnx(path);
-
-            assertNotNull(modelData);
             assertNotNull(modelData.nativeHandle());
         } finally {
-            if (modelData != null) {
-                modelData.close();
-                assertNull(modelData.nativeHandle());
+            modelData.close();
+            assertNull(modelData.nativeHandle());
 
-                // close() is an idempotent operation
-                modelData.close();
-            }
+            // close() is an idempotent operation
+            modelData.close();
         }
     }
 

--- a/menoh/src/test/java/jp/preferred/menoh/TestUtils.java
+++ b/menoh/src/test/java/jp/preferred/menoh/TestUtils.java
@@ -4,6 +4,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.ByteBuffer;
 import java.nio.file.Paths;
 
 public class TestUtils {
@@ -44,9 +45,21 @@ public class TestUtils {
     /**
      * make {@link ModelBuilder} and attach the specified input.
      */
-    public static ModelBuilder makeModelBuilderWithInput(VariableProfileTable vpt, String inputName, float[] input) {
+    public static ModelBuilder makeModelBuilderWithInput(
+            VariableProfileTable vpt, String inputName, ByteBuffer inputData) {
         final ModelBuilder builder = ModelBuilder.make(vpt);
-        builder.attach(inputName, input);
+        builder.attach(inputName, inputData);
+
+        return builder;
+    }
+
+    /**
+     * make {@link ModelBuilder} and attach the specified input.
+     */
+    public static ModelBuilder makeModelBuilderWithInput(
+            VariableProfileTable vpt, String inputName, float[] inputData) {
+        final ModelBuilder builder = ModelBuilder.make(vpt);
+        builder.attach(inputName, inputData);
 
         return builder;
     }

--- a/menoh/src/test/java/jp/preferred/menoh/VariableProfileTableBuilderTest.java
+++ b/menoh/src/test/java/jp/preferred/menoh/VariableProfileTableBuilderTest.java
@@ -10,20 +10,15 @@ import org.junit.jupiter.api.Test;
 public class VariableProfileTableBuilderTest {
     @Test
     public void makeVptBuilderIsSuccessful() {
-        VariableProfileTableBuilder builder = null;
+        final VariableProfileTableBuilder builder = VariableProfileTableBuilder.make();
         try {
-            builder = VariableProfileTableBuilder.make();
-
-            assertNotNull(builder);
             assertNotNull(builder.nativeHandle());
         } finally {
-            if (builder != null) {
-                builder.close();
-                assertNull(builder.nativeHandle());
+            builder.close();
+            assertNull(builder.nativeHandle());
 
-                // close() is an idempotent operation
-                builder.close();
-            }
+            // close() is an idempotent operation
+            builder.close();
         }
     }
 
@@ -112,7 +107,7 @@ public class VariableProfileTableBuilderTest {
     }
 
     @Test
-    public void closeVariableProfileTableIsIdempotent() throws Exception {
+    public void closeVariableProfileTable() throws Exception {
         final String path = getResourceFilePath("models/and_op.onnx");
         final int batchSize = 1;
         final int inputDim = 2;
@@ -121,18 +116,15 @@ public class VariableProfileTableBuilderTest {
                 ModelData modelData = ModelData.makeFromOnnx(path);
                 VariableProfileTableBuilder vptBuilder = makeVptBuilderForAndModel(new int[] {batchSize, inputDim})
         ) {
-            VariableProfileTable vpt = null;
+            final VariableProfileTable vpt = vptBuilder.build(modelData);
             try {
-                vpt = vptBuilder.build(modelData);
                 assertNotNull(vpt.nativeHandle());
             } finally {
-                if (vpt != null) {
-                    vpt.close();
-                    assertNull(vpt.nativeHandle());
+                vpt.close();
+                assertNull(vpt.nativeHandle());
 
-                    // close() is an idempotent operation
-                    vpt.close();
-                }
+                // close() is an idempotent operation
+                vpt.close();
             }
         }
     }


### PR DESCRIPTION
- Add `attachedBuffers` field to `Model` and `ModelBuilder` which prevent the pointers to attached buffer from being garbage collected
- Copy `float[]` values to an allocated native memory directly instead of creating `ByteBuffer`
- Add unit tests