### PR TITLE
API improvements (part 1)

### DIFF
--- a/menoh/src/main/java/jp/preferred/menoh/Model.java
+++ b/menoh/src/main/java/jp/preferred/menoh/Model.java
@@ -45,6 +45,16 @@ public class Model implements AutoCloseable {
     }
 
     /**
+     * Creates a {@link ModelBuilder}.
+     */
+    public static ModelBuilder builder(VariableProfileTable vpt) throws MenohException {
+        final PointerByReference ref = new PointerByReference();
+        checkError(MenohNative.INSTANCE.menoh_make_model_builder(vpt.nativeHandle(), ref));
+
+        return new ModelBuilder(ref.getValue());
+    }
+
+    /**
      * Returns a {@link Variable} with the specified name.
      */
     public Variable variable(String variableName) throws MenohException {

--- a/menoh/src/main/java/jp/preferred/menoh/ModelBuilder.java
+++ b/menoh/src/main/java/jp/preferred/menoh/ModelBuilder.java
@@ -73,16 +73,17 @@ public class ModelBuilder implements AutoCloseable {
      *
      * @param variableName the name of the variable
      * @param buffer the byte buffer from which to copy
+     * @return this object
      *
      * @throws IllegalArgumentException if <code>buffer</code> is null or empty
      */
-    public void attach(String variableName, ByteBuffer buffer) throws MenohException {
+    public ModelBuilder attach(String variableName, ByteBuffer buffer) throws MenohException {
         final Pointer bufferHandle = copyToNativeMemory(buffer);
         synchronized (this) {
             attachedBuffers.add(bufferHandle);
         }
 
-        attachImpl(variableName, bufferHandle);
+        return attachImpl(variableName, bufferHandle);
     }
 
     /**
@@ -91,11 +92,12 @@ public class ModelBuilder implements AutoCloseable {
      *
      * @param variableName the name of the variable
      * @param values the byte buffer from which to copy
+     * @return this object
      *
      * @throws IllegalArgumentException if <code>values</code> is null or empty
      */
-    public void attach(String variableName, float[] values) throws MenohException {
-        attach(variableName, values, 0, values.length);
+    public ModelBuilder attach(String variableName, float[] values) throws MenohException {
+        return attach(variableName, values, 0, values.length);
     }
 
     /**
@@ -106,21 +108,24 @@ public class ModelBuilder implements AutoCloseable {
      * @param values the byte buffer from which to copy
      * @param offset the array index from which to start copying
      * @param length the number of elements from <code>values</code> that must be copied
+     * @return this object
      *
      * @throws IllegalArgumentException if <code>values</code> is null or empty
      */
-    public void attach(String variableName, float[] values, int offset, int length) throws MenohException {
+    public ModelBuilder attach(String variableName, float[] values, int offset, int length) throws MenohException {
         final Pointer bufferHandle = copyToNativeMemory(values, offset, length);
         synchronized (this) {
             attachedBuffers.add(bufferHandle);
         }
 
-        attachImpl(variableName, bufferHandle);
+        return attachImpl(variableName, bufferHandle);
     }
 
-    private void attachImpl(String variableName, Pointer bufferHandle) throws MenohException {
+    private ModelBuilder attachImpl(String variableName, Pointer bufferHandle) throws MenohException {
         checkError(MenohNative.INSTANCE.menoh_model_builder_attach_external_buffer(
                 handle, variableName, bufferHandle));
+
+        return this;
     }
 
     /**

--- a/menoh/src/main/java/jp/preferred/menoh/ModelBuilder.java
+++ b/menoh/src/main/java/jp/preferred/menoh/ModelBuilder.java
@@ -22,7 +22,7 @@ public class ModelBuilder implements AutoCloseable {
      */
     private final List<Pointer> attachedBuffers = new ArrayList<>();
 
-    private ModelBuilder(Pointer handle) {
+    ModelBuilder(Pointer handle) {
         this.handle = handle;
     }
 
@@ -46,16 +46,6 @@ public class ModelBuilder implements AutoCloseable {
                 attachedBuffers.clear();
             }
         }
-    }
-
-    /**
-     * Creates a {@link ModelBuilder}.
-     */
-    public static ModelBuilder make(VariableProfileTable vpt) throws MenohException {
-        final PointerByReference ref = new PointerByReference();
-        checkError(MenohNative.INSTANCE.menoh_make_model_builder(vpt.nativeHandle(), ref));
-
-        return new ModelBuilder(ref.getValue());
     }
 
     /**

--- a/menoh/src/main/java/jp/preferred/menoh/ModelData.java
+++ b/menoh/src/main/java/jp/preferred/menoh/ModelData.java
@@ -21,9 +21,13 @@ public class ModelData implements AutoCloseable {
 
     /**
      * Optimizes this model data.
+     *
+     * @return this object
      */
-    public void optimize(VariableProfileTable vpt) throws MenohException {
+    public ModelData optimize(VariableProfileTable vpt) throws MenohException {
         checkError(MenohNative.INSTANCE.menoh_model_data_optimize(handle, vpt.nativeHandle()));
+
+        return this;
     }
 
     @Override

--- a/menoh/src/main/java/jp/preferred/menoh/Variable.java
+++ b/menoh/src/main/java/jp/preferred/menoh/Variable.java
@@ -26,7 +26,7 @@ public class Variable {
     }
 
     /**
-     * A array of dimension size.
+     * An array of dimension size.
      */
     public int[] dims() {
         if (dims != null) {
@@ -37,23 +37,34 @@ public class Variable {
     }
 
     /**
+     * The length of buffer.
+     */
+    public long length() {
+        if (dims.length > 0) {
+            long length = 1;
+            for (int d : dims) {
+                length *= d;
+            }
+
+            if (length <= 0) {
+                throw new MenohException(ErrorCode.UNDEFINED, "buffer is empty");
+            }
+
+            return length;
+        } else {
+            throw new MenohException(ErrorCode.UNDEFINED, "buffer is empty");
+        }
+    }
+
+    /**
      * A direct {@link ByteBuffer} which points to the native buffer of the variable. The buffer can be read
      * and written via the methods of <code>ByteBuffer</code> before and after running the model.
      */
     public ByteBuffer buffer() throws MenohException {
         final long offset = 0;
         final long elementSize = dtype.size();
+        final long totalLength = elementSize * this.length();
 
-        long length;
-        if (dims.length > 0) {
-            length = 1;
-            for (int d : dims) {
-                length *= d;
-            }
-        } else {
-            length = 0;
-        }
-
-        return this.bufferHandle.getByteBuffer(offset, elementSize * length);
+        return this.bufferHandle.getByteBuffer(offset, totalLength);
     }
 }

--- a/menoh/src/main/java/jp/preferred/menoh/VariableProfileTable.java
+++ b/menoh/src/main/java/jp/preferred/menoh/VariableProfileTable.java
@@ -4,6 +4,7 @@ import static jp.preferred.menoh.MenohException.checkError;
 
 import com.sun.jna.Pointer;
 import com.sun.jna.ptr.IntByReference;
+import com.sun.jna.ptr.PointerByReference;
 
 /**
  * A table which holds {@link VariableProfile}s for the {@link Model}. It will be built by
@@ -28,6 +29,16 @@ public class VariableProfileTable implements AutoCloseable {
                 handle = Pointer.NULL;
             }
         }
+    }
+
+    /**
+     * Creates a {@link VariableProfileTableBuilder}.
+     */
+    public static VariableProfileTableBuilder builder() throws MenohException {
+        final PointerByReference ref = new PointerByReference();
+        checkError(MenohNative.INSTANCE.menoh_make_variable_profile_table_builder(ref));
+
+        return new VariableProfileTableBuilder(ref.getValue());
     }
 
     /**

--- a/menoh/src/main/java/jp/preferred/menoh/VariableProfileTableBuilder.java
+++ b/menoh/src/main/java/jp/preferred/menoh/VariableProfileTableBuilder.java
@@ -11,7 +11,7 @@ import com.sun.jna.ptr.PointerByReference;
 public class VariableProfileTableBuilder implements AutoCloseable {
     private Pointer handle;
 
-    private VariableProfileTableBuilder(Pointer handle) {
+    VariableProfileTableBuilder(Pointer handle) {
         this.handle = handle;
     }
 
@@ -27,16 +27,6 @@ public class VariableProfileTableBuilder implements AutoCloseable {
                 handle = Pointer.NULL;
             }
         }
-    }
-
-    /**
-     * Creates a {@link VariableProfileTableBuilder}.
-     */
-    public static VariableProfileTableBuilder make() throws MenohException {
-        final PointerByReference ref = new PointerByReference();
-        checkError(MenohNative.INSTANCE.menoh_make_variable_profile_table_builder(ref));
-
-        return new VariableProfileTableBuilder(ref.getValue());
     }
 
     /**

--- a/menoh/src/main/java/jp/preferred/menoh/VariableProfileTableBuilder.java
+++ b/menoh/src/main/java/jp/preferred/menoh/VariableProfileTableBuilder.java
@@ -41,8 +41,10 @@ public class VariableProfileTableBuilder implements AutoCloseable {
 
     /**
      * Adds an input profile to configure the specified variable of the model.
+     *
+     * @return this object
      */
-    public void addInputProfile(String name, DType dtype, int[] dims) throws MenohException {
+    public VariableProfileTableBuilder addInputProfile(String name, DType dtype, int[] dims) throws MenohException {
         if (dims.length == 2) {
             checkError(
                     MenohNative.INSTANCE.menoh_variable_profile_table_builder_add_input_profile_dims_2(
@@ -56,14 +58,20 @@ public class VariableProfileTableBuilder implements AutoCloseable {
                     ErrorCode.UNDEFINED,
                     String.format("%s has an invalid dims size: %d (it must be 2 or 4)", name, dims.length));
         }
+
+        return this;
     }
 
     /**
      * Adds an output profile to configure the specified variable of the model.
+     *
+     * @return this object
      */
-    public void addOutputProfile(String name, DType dtype) throws MenohException {
+    public VariableProfileTableBuilder addOutputProfile(String name, DType dtype) throws MenohException {
         checkError(MenohNative.INSTANCE.menoh_variable_profile_table_builder_add_output_profile(
                 handle, name, dtype.getId()));
+
+        return this;
     }
 
     /**

--- a/menoh/src/test/java/jp/preferred/menoh/ModelDataTest.java
+++ b/menoh/src/test/java/jp/preferred/menoh/ModelDataTest.java
@@ -81,7 +81,9 @@ public class ModelDataTest {
 
         try (
                 ModelData modelData = ModelData.makeFromOnnx(path);
-                VariableProfileTableBuilder vptBuilder = makeVptBuilderForAndModel(new int[] {1, 2});
+                VariableProfileTableBuilder vptBuilder = VariableProfileTable.builder()
+                        .addInputProfile("input", DType.FLOAT, new int[] {1, 2})
+                        .addOutputProfile("output", DType.FLOAT);
                 VariableProfileTable vpt = vptBuilder.build(modelData)
         ) {
             modelData.optimize(vpt);

--- a/menoh/src/test/java/jp/preferred/menoh/ModelTest.java
+++ b/menoh/src/test/java/jp/preferred/menoh/ModelTest.java
@@ -10,7 +10,7 @@ import java.nio.ByteOrder;
 
 import org.junit.jupiter.api.Test;
 
-public class ModelBuilderTest {
+public class ModelTest {
     @Test
     public void makeModelBuilderIsSuccessful() throws Exception {
         final String path = getResourceFilePath("models/and_op.onnx");
@@ -20,9 +20,11 @@ public class ModelBuilderTest {
 
         try (
                 ModelData modelData = ModelData.makeFromOnnx(path);
-                VariableProfileTableBuilder vptBuilder = makeVptBuilderForAndModel(new int[] {batchSize, inputDim});
+                VariableProfileTableBuilder vptBuilder = VariableProfileTable.builder()
+                        .addInputProfile("input", DType.FLOAT, new int[] {batchSize, inputDim})
+                        .addOutputProfile("output", DType.FLOAT);
                 VariableProfileTable vpt = vptBuilder.build(modelData);
-                ModelBuilder modelBuilder = ModelBuilder.make(vpt)
+                ModelBuilder modelBuilder = Model.builder(vpt)
         ) {
             modelBuilder.attach("input", inputData);
 
@@ -44,10 +46,12 @@ public class ModelBuilderTest {
 
         try (
                 ModelData modelData = ModelData.makeFromOnnx(path);
-                VariableProfileTableBuilder vptBuilder = makeVptBuilderForAndModel(new int[] {batchSize, inputDim});
-                VariableProfileTable vpt = vptBuilder.build(modelData);
+                VariableProfileTableBuilder vptBuilder = VariableProfileTable.builder()
+                        .addInputProfile("input", DType.FLOAT, new int[] {batchSize, inputDim})
+                        .addOutputProfile("output", DType.FLOAT);
+                VariableProfileTable vpt = vptBuilder.build(modelData)
         ) {
-            final ModelBuilder modelBuilder = ModelBuilder.make(vpt);
+            final ModelBuilder modelBuilder = Model.builder(vpt);
             try {
                 modelBuilder.attach("input", inputData);
 
@@ -82,9 +86,11 @@ public class ModelBuilderTest {
 
         try (
                 ModelData modelData = ModelData.makeFromOnnx(path);
-                VariableProfileTableBuilder vptBuilder = makeVptBuilderForAndModel(new int[] {batchSize, inputDim});
+                VariableProfileTableBuilder vptBuilder = VariableProfileTable.builder()
+                        .addInputProfile("input", DType.FLOAT, new int[] {batchSize, inputDim})
+                        .addOutputProfile("output", DType.FLOAT);
                 VariableProfileTable vpt = vptBuilder.build(modelData);
-                ModelBuilder modelBuilder = ModelBuilder.make(vpt)
+                ModelBuilder modelBuilder = Model.builder(vpt)
         ) {
             modelBuilder.attach("input", new float[] {0f, 0f, 0f, 1f, 1f, 0f, 1f, 1f});
             assertTrue(!modelBuilder.attachedBuffers().isEmpty(), "attachedBuffers should not be empty");
@@ -111,9 +117,11 @@ public class ModelBuilderTest {
 
         try (
                 ModelData modelData = ModelData.makeFromOnnx(path);
-                VariableProfileTableBuilder vptBuilder = makeVptBuilderForAndModel(new int[] {batchSize, inputDim});
+                VariableProfileTableBuilder vptBuilder = VariableProfileTable.builder()
+                        .addInputProfile("input", DType.FLOAT, new int[] {batchSize, inputDim})
+                        .addOutputProfile("output", DType.FLOAT);
                 VariableProfileTable vpt = vptBuilder.build(modelData);
-                ModelBuilder modelBuilder = ModelBuilder.make(vpt)
+                ModelBuilder modelBuilder = Model.builder(vpt)
         ) {
             modelBuilder.attach("input", input);
             assertTrue(!modelBuilder.attachedBuffers().isEmpty(), "attachedBuffers should not be empty");
@@ -156,10 +164,12 @@ public class ModelBuilderTest {
 
         try (
                 ModelData modelData = ModelData.makeFromOnnx(path);
-                VariableProfileTableBuilder vptBuilder = makeVptBuilderForAndModel(new int[] {batchSize, inputDim});
+                VariableProfileTableBuilder vptBuilder = VariableProfileTable.builder()
+                        .addInputProfile("input", DType.FLOAT, new int[] {batchSize, inputDim})
+                        .addOutputProfile("output", DType.FLOAT);
                 VariableProfileTable vpt = vptBuilder.build(modelData)
         ) {
-            try (ModelBuilder modelBuilder = ModelBuilder.make(vpt)) {
+            try (ModelBuilder modelBuilder = Model.builder(vpt)) {
                 modelBuilder.attach("input", input);
                 assertTrue(!modelBuilder.attachedBuffers().isEmpty(), "attachedBuffers should not be empty");
 
@@ -196,9 +206,11 @@ public class ModelBuilderTest {
 
         try (
                 ModelData modelData = ModelData.makeFromOnnx(path);
-                VariableProfileTableBuilder vptBuilder = makeVptBuilderForAndModel(new int[] {batchSize, inputDim});
+                VariableProfileTableBuilder vptBuilder = VariableProfileTable.builder()
+                        .addInputProfile("input", DType.FLOAT, new int[] {batchSize, inputDim})
+                        .addOutputProfile("output", DType.FLOAT);
                 VariableProfileTable vpt = vptBuilder.build(modelData);
-                ModelBuilder modelBuilder = ModelBuilder.make(vpt)
+                ModelBuilder modelBuilder = Model.builder(vpt)
         ) {
             modelBuilder.attach("input", new float[] {0f, 0f, 0f, 1f, 1f, 0f, 1f, 1f});
 
@@ -227,9 +239,11 @@ public class ModelBuilderTest {
 
         try (
                 ModelData modelData = ModelData.makeFromOnnx(path);
-                VariableProfileTableBuilder vptBuilder = makeVptBuilderForAndModel(new int[] {batchSize, inputDim});
+                VariableProfileTableBuilder vptBuilder = VariableProfileTable.builder()
+                        .addInputProfile("input", DType.FLOAT, new int[] {batchSize, inputDim})
+                        .addOutputProfile("output", DType.FLOAT);
                 VariableProfileTable vpt = vptBuilder.build(modelData);
-                ModelBuilder modelBuilder = ModelBuilder.make(vpt); // test case
+                ModelBuilder modelBuilder = Model.builder(vpt); // test case
                 Model model = modelBuilder.build(modelData, "mkldnn", "")
         ) {
             // you can delete modelData explicitly after building a model
@@ -286,9 +300,11 @@ public class ModelBuilderTest {
 
         try (
                 ModelData modelData = ModelData.makeFromOnnx(path);
-                VariableProfileTableBuilder vptBuilder = makeVptBuilderForAndModel(new int[] {batchSize, inputDim});
+                VariableProfileTableBuilder vptBuilder = VariableProfileTable.builder()
+                        .addInputProfile("input", DType.FLOAT, new int[] {batchSize, inputDim})
+                        .addOutputProfile("output", DType.FLOAT);
                 VariableProfileTable vpt = vptBuilder.build(modelData);
-                ModelBuilder modelBuilder = makeModelBuilderWithInput(vpt, "input", inputDataBuf);
+                ModelBuilder modelBuilder = Model.builder(vpt).attach("input", inputDataBuf);
                 Model model = modelBuilder.build(modelData, "mkldnn", "")
         ) {
             // you can delete modelData explicitly after building a model
@@ -346,9 +362,11 @@ public class ModelBuilderTest {
 
         try (
                 ModelData modelData = ModelData.makeFromOnnx(path);
-                VariableProfileTableBuilder vptBuilder = makeVptBuilderForAndModel(new int[] {batchSize, inputDim});
+                VariableProfileTableBuilder vptBuilder = VariableProfileTable.builder()
+                        .addInputProfile("input", DType.FLOAT, new int[] {batchSize, inputDim})
+                        .addOutputProfile("output", DType.FLOAT);
                 VariableProfileTable vpt = vptBuilder.build(modelData);
-                ModelBuilder modelBuilder = makeModelBuilderWithInput(vpt, "input", inputDataBuf);
+                ModelBuilder modelBuilder = Model.builder(vpt).attach("input", inputDataBuf);
                 Model model = modelBuilder.build(modelData, "mkldnn", "")
         ) {
             // you can delete modelData explicitly after building a model
@@ -393,9 +411,11 @@ public class ModelBuilderTest {
 
         try (
                 ModelData modelData = ModelData.makeFromOnnx(path);
-                VariableProfileTableBuilder vptBuilder = makeVptBuilderForAndModel(new int[] {batchSize, inputDim});
+                VariableProfileTableBuilder vptBuilder = VariableProfileTable.builder()
+                        .addInputProfile("input", DType.FLOAT, new int[] {batchSize, inputDim})
+                        .addOutputProfile("output", DType.FLOAT);
                 VariableProfileTable vpt = vptBuilder.build(modelData);
-                ModelBuilder modelBuilder = makeModelBuilderWithInput(vpt, "input", readOnlyInputDataBuf);
+                ModelBuilder modelBuilder = Model.builder(vpt).attach("input", readOnlyInputDataBuf);
                 Model model = modelBuilder.build(modelData, "mkldnn", "")
         ) {
             // you can delete modelData explicitly after building a model
@@ -436,9 +456,11 @@ public class ModelBuilderTest {
 
         try (
                 ModelData modelData = ModelData.makeFromOnnx(path);
-                VariableProfileTableBuilder vptBuilder = makeVptBuilderForAndModel(new int[] {batchSize, inputDim});
+                VariableProfileTableBuilder vptBuilder = VariableProfileTable.builder()
+                        .addInputProfile("input", DType.FLOAT, new int[] {batchSize, inputDim})
+                        .addOutputProfile("output", DType.FLOAT);
                 VariableProfileTable vpt = vptBuilder.build(modelData);
-                ModelBuilder modelBuilder = makeModelBuilderWithInput(vpt, "input", inputData);
+                ModelBuilder modelBuilder = Model.builder(vpt).attach("input", inputData);
                 Model model = modelBuilder.build(modelData, "mkldnn", "")
         ) {
             // you can delete modelData explicitly after building a model

--- a/menoh/src/test/java/jp/preferred/menoh/TestUtils.java
+++ b/menoh/src/test/java/jp/preferred/menoh/TestUtils.java
@@ -4,7 +4,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.ByteBuffer;
 import java.nio.file.Paths;
 
 public class TestUtils {
@@ -19,48 +18,5 @@ public class TestUtils {
         } else {
             throw new FileNotFoundException("The specified resource not found: " + name);
         }
-    }
-
-    /**
-     * make {@link VariableProfileTableBuilder} for the {@link ModelData} made from `and_op.onnx`.
-     */
-    public static VariableProfileTableBuilder makeVptBuilderForAndModel(int[] inputDims) {
-        return makeVptBuilderForAndModel("input", inputDims, "output");
-    }
-
-    /**
-     * make {@link VariableProfileTableBuilder} for the {@link ModelData} made from `and_op.onnx`.
-     */
-    public static VariableProfileTableBuilder makeVptBuilderForAndModel(
-            String inputProfileName,
-            int[] inputDims,
-            String outputProfileName) {
-        final VariableProfileTableBuilder builder = VariableProfileTableBuilder.make();
-        builder.addInputProfile(inputProfileName, DType.FLOAT, inputDims);
-        builder.addOutputProfile(outputProfileName, DType.FLOAT);
-
-        return builder;
-    }
-
-    /**
-     * make {@link ModelBuilder} and attach the specified input.
-     */
-    public static ModelBuilder makeModelBuilderWithInput(
-            VariableProfileTable vpt, String inputName, ByteBuffer inputData) {
-        final ModelBuilder builder = ModelBuilder.make(vpt);
-        builder.attach(inputName, inputData);
-
-        return builder;
-    }
-
-    /**
-     * make {@link ModelBuilder} and attach the specified input.
-     */
-    public static ModelBuilder makeModelBuilderWithInput(
-            VariableProfileTable vpt, String inputName, float[] inputData) {
-        final ModelBuilder builder = ModelBuilder.make(vpt);
-        builder.attach(inputName, inputData);
-
-        return builder;
     }
 }

--- a/menoh/src/test/java/jp/preferred/menoh/VariableProfileTableTest.java
+++ b/menoh/src/test/java/jp/preferred/menoh/VariableProfileTableTest.java
@@ -7,10 +7,10 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
 
-public class VariableProfileTableBuilderTest {
+public class VariableProfileTableTest {
     @Test
     public void makeVptBuilderIsSuccessful() {
-        final VariableProfileTableBuilder builder = VariableProfileTableBuilder.make();
+        final VariableProfileTableBuilder builder = VariableProfileTable.builder();
         try {
             assertNotNull(builder.nativeHandle());
         } finally {
@@ -24,14 +24,14 @@ public class VariableProfileTableBuilderTest {
 
     @Test
     public void addValidInputProfile() {
-        try (VariableProfileTableBuilder builder = VariableProfileTableBuilder.make()) {
+        try (VariableProfileTableBuilder builder = VariableProfileTable.builder()) {
             builder.addInputProfile("foo", DType.FLOAT, new int[] {1, 1});
         }
     }
 
     @Test
     public void addValidInputProfileWithInvalidDims() {
-        try (VariableProfileTableBuilder builder = VariableProfileTableBuilder.make()) {
+        try (VariableProfileTableBuilder builder = VariableProfileTable.builder()) {
             MenohException e = assertThrows(MenohException.class,
                     // test case: dims.length == 1
                     () -> builder.addInputProfile("foo", DType.FLOAT, new int[] {1, 1, 1, 1, 1}));
@@ -45,7 +45,7 @@ public class VariableProfileTableBuilderTest {
 
     @Test
     public void addValidOutputProfile() {
-        try (VariableProfileTableBuilder builder = VariableProfileTableBuilder.make()) {
+        try (VariableProfileTableBuilder builder = VariableProfileTable.builder()) {
             builder.addOutputProfile("foo", DType.FLOAT);
         }
     }
@@ -59,7 +59,9 @@ public class VariableProfileTableBuilderTest {
 
         try (
                 ModelData modelData = ModelData.makeFromOnnx(path);
-                VariableProfileTableBuilder vptBuilder = makeVptBuilderForAndModel(new int[] {batchSize, inputDim});
+                VariableProfileTableBuilder vptBuilder = VariableProfileTable.builder()
+                        .addInputProfile("input", DType.FLOAT, new int[] {batchSize, inputDim})
+                        .addOutputProfile("output", DType.FLOAT);
                 VariableProfileTable vpt = vptBuilder.build(modelData)
         ) {
             assertNotNull(vpt.nativeHandle());
@@ -87,7 +89,9 @@ public class VariableProfileTableBuilderTest {
 
         try (
                 ModelData modelData = ModelData.makeFromOnnx(path);
-                VariableProfileTableBuilder vptBuilder = makeVptBuilderForAndModel(new int[] {batchSize, inputDim});
+                VariableProfileTableBuilder vptBuilder = VariableProfileTable.builder()
+                        .addInputProfile("input", DType.FLOAT, new int[] {batchSize, inputDim})
+                        .addOutputProfile("output", DType.FLOAT);
                 VariableProfileTable vpt = vptBuilder.build(modelData)
         ) {
             assertNotNull(vpt.nativeHandle());
@@ -114,7 +118,9 @@ public class VariableProfileTableBuilderTest {
 
         try (
                 ModelData modelData = ModelData.makeFromOnnx(path);
-                VariableProfileTableBuilder vptBuilder = makeVptBuilderForAndModel(new int[] {batchSize, inputDim})
+                VariableProfileTableBuilder vptBuilder = VariableProfileTable.builder()
+                        .addInputProfile("input", DType.FLOAT, new int[] {batchSize, inputDim})
+                        .addOutputProfile("output", DType.FLOAT)
         ) {
             final VariableProfileTable vpt = vptBuilder.build(modelData);
             try {
@@ -140,9 +146,9 @@ public class VariableProfileTableBuilderTest {
 
         try (
                 ModelData modelData = ModelData.makeFromOnnx(path);
-                VariableProfileTableBuilder vptBuilder =
-                        makeVptBuilderForAndModel(
-                            inputProfileName, new int[] {batchSize, inputDim}, outputProfileName)
+                VariableProfileTableBuilder vptBuilder = VariableProfileTable.builder()
+                        .addInputProfile(inputProfileName, DType.FLOAT, new int[] {batchSize, inputDim})
+                        .addOutputProfile(outputProfileName, DType.FLOAT)
         ) {
             MenohException e = assertThrows(MenohException.class, () -> vptBuilder.build(modelData));
             assertAll("input profile name not found",
@@ -165,9 +171,9 @@ public class VariableProfileTableBuilderTest {
 
         try (
                 ModelData modelData = ModelData.makeFromOnnx(path);
-                VariableProfileTableBuilder vptBuilder =
-                        makeVptBuilderForAndModel(
-                                inputProfileName, new int[] {batchSize, inputDim}, outputProfileName)
+                VariableProfileTableBuilder vptBuilder = VariableProfileTable.builder()
+                        .addInputProfile(inputProfileName, DType.FLOAT, new int[] {batchSize, inputDim})
+                        .addOutputProfile(outputProfileName, DType.FLOAT)
         ) {
             MenohException e = assertThrows(MenohException.class, () -> vptBuilder.build(modelData));
             assertAll("mismatched input dims",
@@ -193,9 +199,9 @@ public class VariableProfileTableBuilderTest {
 
         try (
                 ModelData modelData = ModelData.makeFromOnnx(path);
-                VariableProfileTableBuilder vptBuilder =
-                        makeVptBuilderForAndModel(
-                            inputProfileName, new int[] {batchSize, inputDim}, outputProfileName)
+                VariableProfileTableBuilder vptBuilder = VariableProfileTable.builder()
+                        .addInputProfile(inputProfileName, DType.FLOAT, new int[] {batchSize, inputDim})
+                        .addOutputProfile(outputProfileName, DType.FLOAT)
         ) {
             MenohException e = assertThrows(MenohException.class, () -> vptBuilder.build(modelData));
             assertAll("output profile name not found",


### PR DESCRIPTION
- Add method chaining functionality
- Add `length` method to `Variable`
- Replace `make()` in the builder classes with `builder()` in `Model` and `VariableProfileTable`

e.g.
```java
try (
    ModelData modelData = ModelData.makeFromOnnx(onnxModelPath);
    VariableProfileTableBuilder vptBuilder = VariableProfileTable.builder()
        .addInputProfile(conv11InName, DType.FLOAT, new int[] {batchSize, channelNum, height, width})
        .addOutputProfile(fc6OutName, DType.FLOAT)
        .addOutputProfile(softmaxOutName, DType.FLOAT);
    VariableProfileTable vpt = vptBuilder.build(modelData);
    ModelBuilder modelBuilder = Model.builder(vpt).attach(conv11InName, imageData);
    Model model = modelBuilder.build(modelData, "mkldnn", "")
) {
    model.run();
    ...
}
```
