### PR TITLE
Add `ModelRunner` and its builder

### DIFF
--- a/menoh-examples/src/main/java/jp/preferred/menoh/examples/Vgg16.java
+++ b/menoh-examples/src/main/java/jp/preferred/menoh/examples/Vgg16.java
@@ -64,13 +64,7 @@ public class Vgg16 {
                         .addOutputProfile(fc6OutName, DType.FLOAT)
                         .addOutputProfile(softmaxOutName, DType.FLOAT)
 
-                        // Make ModelBuilder and attach extenal memory buffer
-                        // Variables which are not attached external memory buffer here are attached
-                        // internal memory buffers which are automatically allocated
-                        .attach(conv11InName, imageData)
-
-                        // Build model
-
+                        // Configure backend
                         .backendName("mkldnn")
                         .backendConfig("");
                  ModelRunner modelRunner = modelRunnerBuilder.build()
@@ -79,7 +73,7 @@ public class Vgg16 {
             modelRunnerBuilder.close();
 
             // Run the inference
-            modelRunner.run();
+            modelRunner.run(conv11InName, imageData);
 
             final Model model = modelRunner.model();
 

--- a/menoh/src/main/java/jp/preferred/menoh/BufferUtils.java
+++ b/menoh/src/main/java/jp/preferred/menoh/BufferUtils.java
@@ -9,8 +9,11 @@ import java.nio.ByteOrder;
 
 class BufferUtils {
     /**
-     * <p>Copies a buffer to an allocated memory in the native heap. It copies the content ranging from
-     * <code>position()</code> to <code>(limit() - 1)</code> without changing them, except for a direct buffer.</p>
+     * <p>Copies a buffer to a native memory.</p>
+     *
+     * <p>If the <code>buffer</code> is direct, it will be attached to the model directly without copying.
+     * Otherwise, it copies the content of the buffer to a newly allocated memory in the native heap ranging
+     * from <code>position()</code> to <code>(limit() - 1)</code> without changing its position.</p>
      *
      * <p>Note that the <code>order()</code> of the buffer should be {@link ByteOrder#nativeOrder()} because
      * the native byte order of your platform may differ from JVM.</p>
@@ -53,7 +56,7 @@ class BufferUtils {
     }
 
     /**
-     * <p>Copies the array to an allocated memory in the native heap.</p>
+     * <p>Copies the array to a newly allocated memory in the native heap.</p>
      *
      * @param values the non-empty array from which to copy
      * @param offset the array index from which to start copying

--- a/menoh/src/main/java/jp/preferred/menoh/MenohRunnerException.java
+++ b/menoh/src/main/java/jp/preferred/menoh/MenohRunnerException.java
@@ -1,0 +1,23 @@
+package jp.preferred.menoh;
+
+public class MenohRunnerException extends RuntimeException {
+    public MenohRunnerException(String message) {
+        super(message);
+    }
+
+    public MenohRunnerException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public MenohRunnerException(Throwable cause) {
+        super(cause);
+    }
+
+    protected MenohRunnerException(
+            String message,
+            Throwable cause,
+            boolean enableSuppression,
+            boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/menoh/src/main/java/jp/preferred/menoh/Model.java
+++ b/menoh/src/main/java/jp/preferred/menoh/Model.java
@@ -17,19 +17,19 @@ public class Model implements AutoCloseable {
     /**
      * A reference to the pointers to prevent them from getting garbage collected.
      */
-    private final List<Pointer> attachedBuffers;
+    private final List<Pointer> externalBuffers;
 
-    Model(Pointer handle, List<Pointer> attachedBuffers) {
+    Model(Pointer handle, List<Pointer> externalBuffers) {
         this.handle = handle;
-        this.attachedBuffers = attachedBuffers;
+        this.externalBuffers = externalBuffers;
     }
 
     Pointer nativeHandle() {
         return this.handle;
     }
 
-    List<Pointer> attachedBuffers() {
-        return this.attachedBuffers;
+    List<Pointer> externalBuffers() {
+        return this.externalBuffers;
     }
 
     @Override
@@ -38,7 +38,7 @@ public class Model implements AutoCloseable {
             if (handle != Pointer.NULL) {
                 MenohNative.INSTANCE.menoh_delete_model(handle);
                 handle = Pointer.NULL;
-                attachedBuffers.clear();
+                externalBuffers.clear();
             }
         }
     }

--- a/menoh/src/main/java/jp/preferred/menoh/Model.java
+++ b/menoh/src/main/java/jp/preferred/menoh/Model.java
@@ -6,7 +6,6 @@ import com.sun.jna.Pointer;
 import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.PointerByReference;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**

--- a/menoh/src/main/java/jp/preferred/menoh/Model.java
+++ b/menoh/src/main/java/jp/preferred/menoh/Model.java
@@ -78,6 +78,9 @@ public class Model implements AutoCloseable {
         return new Variable(DType.valueOf(dtype.getValue()), dims, buffer.getValue());
     }
 
+    /**
+     * Run this model.
+     */
     public void run() throws MenohException {
         checkError(MenohNative.INSTANCE.menoh_model_run(handle));
     }

--- a/menoh/src/main/java/jp/preferred/menoh/ModelBuilder.java
+++ b/menoh/src/main/java/jp/preferred/menoh/ModelBuilder.java
@@ -66,7 +66,7 @@ public class ModelBuilder implements AutoCloseable {
      *
      * @throws IllegalArgumentException if <code>buffer</code> is null or empty
      */
-    public ModelBuilder attach(String variableName, ByteBuffer buffer) throws MenohException {
+    public ModelBuilder attachExternalBuffer(String variableName, ByteBuffer buffer) throws MenohException {
         final Pointer bufferHandle = copyToNativeMemory(buffer);
         synchronized (this) {
             externalBuffers.add(bufferHandle);
@@ -87,8 +87,8 @@ public class ModelBuilder implements AutoCloseable {
      *
      * @throws IllegalArgumentException if <code>values</code> is null or empty
      */
-    public ModelBuilder attach(String variableName, float[] values) throws MenohException {
-        return attach(variableName, values, 0, values.length);
+    public ModelBuilder attachExternalBuffer(String variableName, float[] values) throws MenohException {
+        return attachExternalBuffer(variableName, values, 0, values.length);
     }
 
     /**
@@ -106,7 +106,8 @@ public class ModelBuilder implements AutoCloseable {
      *
      * @throws IllegalArgumentException if <code>values</code> is null or empty
      */
-    public ModelBuilder attach(String variableName, float[] values, int offset, int length) throws MenohException {
+    public ModelBuilder attachExternalBuffer(
+            String variableName, float[] values, int offset, int length) throws MenohException {
         final Pointer bufferHandle = copyToNativeMemory(values, offset, length);
         synchronized (this) {
             externalBuffers.add(bufferHandle);

--- a/menoh/src/main/java/jp/preferred/menoh/ModelBuilder.java
+++ b/menoh/src/main/java/jp/preferred/menoh/ModelBuilder.java
@@ -20,7 +20,7 @@ public class ModelBuilder implements AutoCloseable {
     /**
      * A reference to the pointers to prevent them from getting garbage collected.
      */
-    private final List<Pointer> attachedBuffers = new ArrayList<>();
+    private final List<Pointer> externalBuffers = new ArrayList<>();
 
     ModelBuilder(Pointer handle) {
         this.handle = handle;
@@ -30,8 +30,8 @@ public class ModelBuilder implements AutoCloseable {
         return this.handle;
     }
 
-    List<Pointer> attachedBuffers() {
-        return this.attachedBuffers;
+    List<Pointer> externalBuffers() {
+        return this.externalBuffers;
     }
 
     /**
@@ -43,20 +43,19 @@ public class ModelBuilder implements AutoCloseable {
             if (handle != Pointer.NULL) {
                 MenohNative.INSTANCE.menoh_delete_model_builder(handle);
                 handle = Pointer.NULL;
-                attachedBuffers.clear();
+                externalBuffers.clear();
             }
         }
     }
 
     /**
-     * <p>Attaches a non-empty buffer to the specified variable.</p>
+     * <p>Attaches a non-empty external buffer to the specified variable.</p>
      *
-     * <p>If the <code>buffer</code> is direct, it will be attached to the model directly without copying.
-     * You can <code>run()</code> the model again and again by updating the attached buffer instead of
-     * rebuilding the model.</p>
+     * <p>If the specified <code>buffer</code> is direct, it will be attached to the model directly without
+     * copying. Otherwise, it copies the content to a newly allocated buffer in the native heap ranging from
+     * <code>position()</code> to <code>(limit() - 1)</code> without changing its position.</p>
      *
-     * <p>Otherwise, it copies the content of the buffer to an allocated memory in the native heap ranging
-     * from <code>position()</code> to <code>(limit() - 1)</code> without changing them.</p>
+     * <p>The attached buffer can be accessed through {@link Model#variable(String)}.</p>
      *
      * <p>Note that the <code>order()</code> of the buffer should be {@link ByteOrder#nativeOrder()} because
      * the native byte order of your platform may differ from JVM.</p>
@@ -70,15 +69,17 @@ public class ModelBuilder implements AutoCloseable {
     public ModelBuilder attach(String variableName, ByteBuffer buffer) throws MenohException {
         final Pointer bufferHandle = copyToNativeMemory(buffer);
         synchronized (this) {
-            attachedBuffers.add(bufferHandle);
+            externalBuffers.add(bufferHandle);
         }
 
         return attachImpl(variableName, bufferHandle);
     }
 
     /**
-     * <p>Attaches a non-empty array to the specified variable. It copies the content of the array to an allocated
-     * memory in the native heap.</p>
+     * <p>Attaches a non-empty external buffer to the specified variable. It also copies the content of the
+     * <code>values</code> to a newly allocated buffer in the native heap.</p>
+     *
+     * <p>The buffer can be accessed through {@link Model#variable(String)}.</p>
      *
      * @param variableName the name of the variable
      * @param values the byte buffer from which to copy
@@ -91,8 +92,11 @@ public class ModelBuilder implements AutoCloseable {
     }
 
     /**
-     * <p>Attaches a non-empty array to the specified variable. It copies the content of the array to an allocated
-     * memory in the native heap ranging from <code>offset</code> to <code>(offset + length - 1)</code>.</p>
+     * <p>Attaches a non-empty external buffer to the specified variable. It also copies the content of the
+     * <code>values</code> to a newly allocated buffer in the native heap ranging from <code>offset</code>
+     * to <code>(offset + length - 1)</code>.</p>
+     *
+     * <p>The buffer can be accessed through {@link Model#variable(String)}.</p>
      *
      * @param variableName the name of the variable
      * @param values the byte buffer from which to copy
@@ -105,7 +109,7 @@ public class ModelBuilder implements AutoCloseable {
     public ModelBuilder attach(String variableName, float[] values, int offset, int length) throws MenohException {
         final Pointer bufferHandle = copyToNativeMemory(values, offset, length);
         synchronized (this) {
-            attachedBuffers.add(bufferHandle);
+            externalBuffers.add(bufferHandle);
         }
 
         return attachImpl(variableName, bufferHandle);
@@ -130,7 +134,7 @@ public class ModelBuilder implements AutoCloseable {
                 this.handle, modelData.nativeHandle(), backendName, backendConfig, ref));
 
         synchronized (this) {
-            return new Model(ref.getValue(), new ArrayList<>(this.attachedBuffers));
+            return new Model(ref.getValue(), new ArrayList<>(this.externalBuffers));
         }
     }
 }

--- a/menoh/src/main/java/jp/preferred/menoh/ModelData.java
+++ b/menoh/src/main/java/jp/preferred/menoh/ModelData.java
@@ -43,7 +43,7 @@ public class ModelData implements AutoCloseable {
     /**
      * Loads an ONNX model from the specified file.
      */
-    public static ModelData makeFromOnnx(String onnxModelPath) throws MenohException {
+    public static ModelData fromOnnxFile(String onnxModelPath) throws MenohException {
         final PointerByReference handle = new PointerByReference();
         checkError(MenohNative.INSTANCE.menoh_make_model_data_from_onnx(onnxModelPath, handle));
 

--- a/menoh/src/main/java/jp/preferred/menoh/ModelRunner.java
+++ b/menoh/src/main/java/jp/preferred/menoh/ModelRunner.java
@@ -1,7 +1,10 @@
 package jp.preferred.menoh;
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * A convenient wrapper for building and running {@link Model}.
@@ -20,10 +23,8 @@ public class ModelRunner implements AutoCloseable {
         this.model = model;
     }
 
-    @Override
-    public void close() {
-        model.close();
-        builder.close();
+    ModelRunnerBuilder builder() {
+        return this.builder;
     }
 
     /**
@@ -31,6 +32,12 @@ public class ModelRunner implements AutoCloseable {
      */
     public Model model() {
         return this.model;
+    }
+
+    @Override
+    public void close() {
+        model.close();
+        builder.close();
     }
 
     public static ModelRunnerBuilder fromOnnxFile(String path) {
@@ -58,7 +65,91 @@ public class ModelRunner implements AutoCloseable {
         }
     }
 
+    /**
+     * <p>Run this model after copying a non-empty array to the specified variable.</p>
+     *
+     * @param name the name of the input variable
+     * @param values the values to be copied to the input variable
+     * @return the output variables of the model
+     */
+    public void run(String name, float[] values) {
+        run(name, values, 0, values.length);
+    }
+
+    /**
+     * <p>Run this model after copying a non-empty array to the specified variable. It copies the content
+     * ranging from <code>offset</code> to <code>(offset + length - 1)</code>.</p>
+     *
+     * @param name the name of the input variable
+     * @param values the values to be copied to the input variable
+     * @return the output variables of the model
+     */
+    public void run(String name, float[] values, int offset, int length) {
+        final ByteBuffer buffer = ByteBuffer.allocateDirect(length * 4).order(ByteOrder.nativeOrder());
+        buffer.asFloatBuffer().put(values, offset, length);
+
+        run(name, buffer);
+    }
+
+    /**
+     * <p>Run this model after copying a non-empty buffer to the specified variable. It copies the content
+     * ranging from <code>position()</code> to <code>(limit() - 1)</code> without changing them, even if
+     * the <code>buffer</code> is direct unlike {@link ModelRunnerBuilder#attach(String, ByteBuffer)}.</p>
+     *
+     * <p>Note that the <code>order()</code> of the buffer should be {@link ByteOrder#nativeOrder()} because
+     * the native byte order of your platform may differ from JVM.</p>
+     *
+     * @param name the name of the input variable
+     * @param buffer the buffer to be copied to the input variable
+     * @return the output variables of the model
+     */
+    public void run(String name, ByteBuffer buffer) {
+        run(Collections.singletonMap(name, buffer));
+    }
+
+    /**
+     * <p>Run this model after copying non-empty buffers to the specified variables. It copies the content
+     * ranging from <code>position()</code> to <code>(limit() - 1)</code> without changing them, even if
+     * the <code>buffer</code> is direct unlike {@link ModelRunnerBuilder#attach(String, ByteBuffer)}.</p>
+     *
+     * <p>Note that the <code>order()</code> of the buffer should be {@link ByteOrder#nativeOrder()} because
+     * the native byte order of your platform may differ from JVM.</p>
+     *
+     * @param buffers the buffers to be copied to the variables
+     * @return the output variables of the model
+     */
+    public void run(final Map<String, ByteBuffer> buffers) {
+        assignToVariables(buffers);
+        model.run();
+    }
+
+    /**
+     * Run this model.
+     */
     public void run() {
         model.run();
+    }
+
+    /**
+     * Assign data to the variables of the model.
+     */
+    private void assignToVariables(final Map<String, ByteBuffer> data) {
+        for (Map.Entry<String, ByteBuffer> e : data.entrySet()) {
+            final String name = e.getKey();
+            final ByteBuffer dataBuf = e.getValue();
+            final long dataLen = dataBuf.remaining();
+
+            final Variable v = model.variable(name);
+            final long varLen = v.bufferLength();
+
+            if (varLen < dataLen) {
+                throw new MenohRunnerException(String.format(
+                        "The data with length > %d can't be assigned to the variable `%s`.", varLen, name));
+            }
+
+            final ByteBuffer varBuf = v.buffer();
+            varBuf.clear();
+            varBuf.put(dataBuf.duplicate()).rewind();
+        }
     }
 }

--- a/menoh/src/main/java/jp/preferred/menoh/ModelRunner.java
+++ b/menoh/src/main/java/jp/preferred/menoh/ModelRunner.java
@@ -87,7 +87,8 @@ public class ModelRunner implements AutoCloseable {
     /**
      * <p>Run this model after assigning a non-empty buffer to the specified variable. It copies the content
      * ranging from <code>position()</code> to <code>(limit() - 1)</code> without changing them, even if
-     * the <code>buffer</code> is direct unlike {@link ModelRunnerBuilder#attach(String, ByteBuffer)}.</p>
+     * the <code>buffer</code> is direct unlike {@link ModelRunnerBuilder#attachExternalBuffer(String, ByteBuffer)}.
+     * </p>
      *
      * <p>Note that the <code>order()</code> of the buffer should be {@link ByteOrder#nativeOrder()} because
      * the native byte order of your platform may differ from JVM.</p>
@@ -102,7 +103,8 @@ public class ModelRunner implements AutoCloseable {
     /**
      * <p>Run this model after assigning non-empty buffers to the specified variables. It copies the content
      * ranging from <code>position()</code> to <code>(limit() - 1)</code> without changing them, even if
-     * the <code>buffer</code> is direct unlike {@link ModelRunnerBuilder#attach(String, ByteBuffer)}.</p>
+     * the <code>buffer</code> is direct unlike {@link ModelRunnerBuilder#attachExternalBuffer(String, ByteBuffer)}.
+     * </p>
      *
      * <p>Note that the <code>order()</code> of the buffer should be {@link ByteOrder#nativeOrder()} because
      * the native byte order of your platform may differ from JVM.</p>

--- a/menoh/src/main/java/jp/preferred/menoh/ModelRunner.java
+++ b/menoh/src/main/java/jp/preferred/menoh/ModelRunner.java
@@ -1,0 +1,64 @@
+package jp.preferred.menoh;
+
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+
+/**
+ * A convenient wrapper for building and running {@link Model}.
+ */
+public class ModelRunner implements AutoCloseable {
+    private final ModelRunnerBuilder builder;
+
+    private final Model model;
+
+    private static final String DEFAULT_BACKEND_NAME = "mkldnn";
+
+    private static final String DEFAULT_BACKEND_CONFIG = "";
+
+    ModelRunner(ModelRunnerBuilder builder, Model model) {
+        this.builder = builder;
+        this.model = model;
+    }
+
+    @Override
+    public void close() {
+        model.close();
+        builder.close();
+    }
+
+    /**
+     * Returns the underlying {@link Model}.
+     */
+    public Model model() {
+        return this.model;
+    }
+
+    public static ModelRunnerBuilder fromOnnxFile(String path) {
+        ModelData modelData = null;
+        VariableProfileTableBuilder vptBuilder = null;
+        try {
+            modelData = ModelData.fromOnnxFile(path);
+            vptBuilder = VariableProfileTable.builder();
+
+            return new ModelRunnerBuilder(
+                    modelData,
+                    vptBuilder,
+                    DEFAULT_BACKEND_NAME,
+                    DEFAULT_BACKEND_CONFIG,
+                    new HashMap<String, ByteBuffer>());
+        } catch (Throwable t) {
+            if (modelData != null) {
+                modelData.close();
+            }
+            if (vptBuilder != null) {
+                vptBuilder.close();
+            }
+
+            throw t;
+        }
+    }
+
+    public void run() {
+        model.run();
+    }
+}

--- a/menoh/src/main/java/jp/preferred/menoh/ModelRunner.java
+++ b/menoh/src/main/java/jp/preferred/menoh/ModelRunner.java
@@ -40,6 +40,9 @@ public class ModelRunner implements AutoCloseable {
         builder.close();
     }
 
+    /**
+     * Loads an ONNX model from the specified file.
+     */
     public static ModelRunnerBuilder fromOnnxFile(String path) {
         ModelData modelData = null;
         VariableProfileTableBuilder vptBuilder = null;
@@ -66,23 +69,21 @@ public class ModelRunner implements AutoCloseable {
     }
 
     /**
-     * <p>Run this model after copying a non-empty array to the specified variable.</p>
+     * <p>Run this model after assigning a non-empty array to the specified variable.</p>
      *
      * @param name the name of the input variable
      * @param values the values to be copied to the input variable
-     * @return the output variables of the model
      */
     public void run(String name, float[] values) {
         run(name, values, 0, values.length);
     }
 
     /**
-     * <p>Run this model after copying a non-empty array to the specified variable. It copies the content
+     * <p>Run this model after assigning a non-empty array to the specified variable. It copies the content
      * ranging from <code>offset</code> to <code>(offset + length - 1)</code>.</p>
      *
      * @param name the name of the input variable
      * @param values the values to be copied to the input variable
-     * @return the output variables of the model
      */
     public void run(String name, float[] values, int offset, int length) {
         final ByteBuffer buffer = ByteBuffer.allocateDirect(length * 4).order(ByteOrder.nativeOrder());
@@ -92,7 +93,7 @@ public class ModelRunner implements AutoCloseable {
     }
 
     /**
-     * <p>Run this model after copying a non-empty buffer to the specified variable. It copies the content
+     * <p>Run this model after assigning a non-empty buffer to the specified variable. It copies the content
      * ranging from <code>position()</code> to <code>(limit() - 1)</code> without changing them, even if
      * the <code>buffer</code> is direct unlike {@link ModelRunnerBuilder#attach(String, ByteBuffer)}.</p>
      *
@@ -101,14 +102,13 @@ public class ModelRunner implements AutoCloseable {
      *
      * @param name the name of the input variable
      * @param buffer the buffer to be copied to the input variable
-     * @return the output variables of the model
      */
     public void run(String name, ByteBuffer buffer) {
         run(Collections.singletonMap(name, buffer));
     }
 
     /**
-     * <p>Run this model after copying non-empty buffers to the specified variables. It copies the content
+     * <p>Run this model after assigning non-empty buffers to the specified variables. It copies the content
      * ranging from <code>position()</code> to <code>(limit() - 1)</code> without changing them, even if
      * the <code>buffer</code> is direct unlike {@link ModelRunnerBuilder#attach(String, ByteBuffer)}.</p>
      *
@@ -116,7 +116,6 @@ public class ModelRunner implements AutoCloseable {
      * the native byte order of your platform may differ from JVM.</p>
      *
      * @param buffers the buffers to be copied to the variables
-     * @return the output variables of the model
      */
     public void run(final Map<String, ByteBuffer> buffers) {
         assignToVariables(buffers);

--- a/menoh/src/main/java/jp/preferred/menoh/ModelRunner.java
+++ b/menoh/src/main/java/jp/preferred/menoh/ModelRunner.java
@@ -10,21 +10,14 @@ import java.util.Map;
  * A convenient wrapper for building and running {@link Model}.
  */
 public class ModelRunner implements AutoCloseable {
-    private final ModelRunnerBuilder builder;
-
     private final Model model;
 
     private static final String DEFAULT_BACKEND_NAME = "mkldnn";
 
     private static final String DEFAULT_BACKEND_CONFIG = "";
 
-    ModelRunner(ModelRunnerBuilder builder, Model model) {
-        this.builder = builder;
+    ModelRunner(Model model) {
         this.model = model;
-    }
-
-    ModelRunnerBuilder builder() {
-        return this.builder;
     }
 
     /**
@@ -37,7 +30,6 @@ public class ModelRunner implements AutoCloseable {
     @Override
     public void close() {
         model.close();
-        builder.close();
     }
 
     /**

--- a/menoh/src/main/java/jp/preferred/menoh/ModelRunnerBuilder.java
+++ b/menoh/src/main/java/jp/preferred/menoh/ModelRunnerBuilder.java
@@ -1,0 +1,157 @@
+package jp.preferred.menoh;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Map;
+
+/**
+ * A builder object for {@link ModelRunner}.
+ */
+public class ModelRunnerBuilder implements AutoCloseable {
+    private final ModelData modelData;
+
+    private final VariableProfileTableBuilder vptBuilder;
+
+    private String backendName;
+
+    private String backendConfig;
+
+    private final Map<String, ByteBuffer> attachedBuffers;
+
+    ModelRunnerBuilder(
+            ModelData modelData,
+            VariableProfileTableBuilder vptBuilder,
+            String backendName,
+            String backendConfig,
+            Map<String, ByteBuffer> attachedBuffers) {
+        this.modelData = modelData;
+        this.vptBuilder = vptBuilder;
+        this.backendName = backendName;
+        this.backendConfig = backendConfig;
+        this.attachedBuffers = attachedBuffers;
+    }
+
+    @Override
+    public void close() {
+        vptBuilder.close();
+        modelData.close();
+
+        // allow the attached buffers to GC its allocated memory
+        attachedBuffers.clear();
+    }
+
+    public ModelRunnerBuilder backendName(String backendName) {
+        this.backendName = backendName;
+        return this;
+    }
+
+    public ModelRunnerBuilder backendConfig(String backendConfig) {
+        this.backendConfig = backendConfig;
+        return this;
+    }
+
+    /**
+     * Adds an input profile to configure the specified variable of the model.
+     *
+     * @return this object
+     */
+    public ModelRunnerBuilder addInputProfile(String name, DType dtype, int[] dims) {
+        vptBuilder.addInputProfile(name, dtype, dims);
+        return this;
+    }
+
+    /**
+     * Adds an output profile to configure the specified variable of the model.
+     *
+     * @return this object
+     */
+    public ModelRunnerBuilder addOutputProfile(String name, DType dtype) {
+        vptBuilder.addOutputProfile(name, dtype);
+        return this;
+    }
+
+    /**
+     * <p>Attaches a non-empty buffer to the specified variable.</p>
+     *
+     * <p>If the <code>buffer</code> is direct, it will be attached to the model directly without copying.
+     * You can <code>run()</code> the model again and again by updating the attached buffer instead of
+     * rebuilding the model.</p>
+     *
+     * <p>Otherwise, it copies the content of the buffer to an allocated memory in the native heap ranging
+     * from <code>position()</code> to <code>(limit() - 1)</code> without changing them.</p>
+     *
+     * <p>Note that the <code>order()</code> of the buffer should be {@link ByteOrder#nativeOrder()} because
+     * the native byte order of your platform may differ from JVM.</p>
+     *
+     * @param variableName the name of the variable
+     * @param buffer the byte buffer from which to copy
+     * @return this object
+     *
+     * @throws IllegalArgumentException if <code>buffer</code> is null or empty
+     */
+    public ModelRunnerBuilder attach(String variableName, ByteBuffer buffer) throws MenohException {
+        attachedBuffers.put(variableName, buffer);
+        return this;
+    }
+
+    /**
+     * <p>Attaches a non-empty array to the specified variable. It copies the content of the array to an allocated
+     * memory in the native heap.</p>
+     *
+     * @param variableName the name of the variable
+     * @param values the byte buffer from which to copy
+     * @return this object
+     *
+     * @throws IllegalArgumentException if <code>values</code> is null or empty
+     */
+    public ModelRunnerBuilder attach(String variableName, float[] values) throws MenohException {
+        return attach(variableName, values, 0, values.length);
+    }
+
+    /**
+     * <p>Attaches a non-empty array to the specified variable. It copies the content of the array to an allocated
+     * memory in the native heap ranging from <code>offset</code> to <code>(offset + length - 1)</code>.</p>
+     *
+     * @param variableName the name of the variable
+     * @param values the byte buffer from which to copy
+     * @param offset the array index from which to start copying
+     * @param length the number of elements from <code>values</code> that must be copied
+     * @return this object
+     *
+     * @throws IllegalArgumentException if <code>values</code> is null or empty
+     */
+    public ModelRunnerBuilder attach(
+            String variableName,
+            float[] values,
+            int offset,
+            int length) throws MenohException {
+        // copy the array to a direct buffer
+        final ByteBuffer buffer = ByteBuffer.allocateDirect(length * 4).order(ByteOrder.nativeOrder());
+        buffer.asFloatBuffer().put(values, offset, length);
+
+        attachedBuffers.put(variableName, buffer);
+        return this;
+    }
+
+    public ModelRunner build() {
+        try (
+                VariableProfileTable vpt = vptBuilder.build(modelData);
+                ModelBuilder modelBuilder = Model.builder(vpt)
+        ) {
+            for (Map.Entry<String, ByteBuffer> e : attachedBuffers.entrySet()) {
+                modelBuilder.attach(e.getKey(), e.getValue());
+            }
+
+            final Model model = modelBuilder.build(modelData, backendName, backendConfig);
+            try {
+                // modelData can be deleted explicitly after building a model
+                modelData.close();
+            } catch (Throwable t) {
+                model.close();
+                throw t;
+            }
+
+            return new ModelRunner(this, model);
+        }
+    }
+}

--- a/menoh/src/main/java/jp/preferred/menoh/ModelRunnerBuilder.java
+++ b/menoh/src/main/java/jp/preferred/menoh/ModelRunnerBuilder.java
@@ -169,15 +169,7 @@ public class ModelRunnerBuilder implements AutoCloseable {
             }
 
             final Model model = modelBuilder.build(modelData, backendName, backendConfig);
-            try {
-                // modelData can be deleted explicitly after building a model
-                modelData.close();
-            } catch (Throwable t) {
-                model.close();
-                throw t;
-            }
-
-            return new ModelRunner(this, model);
+            return new ModelRunner(model);
         }
     }
 }

--- a/menoh/src/main/java/jp/preferred/menoh/ModelRunnerBuilder.java
+++ b/menoh/src/main/java/jp/preferred/menoh/ModelRunnerBuilder.java
@@ -43,8 +43,18 @@ public class ModelRunnerBuilder implements AutoCloseable {
         return this.backendName;
     }
 
+    public ModelRunnerBuilder backendName(String backendName) {
+        this.backendName = backendName;
+        return this;
+    }
+
     String backendConfig() {
         return this.backendConfig;
+    }
+
+    public ModelRunnerBuilder backendConfig(String backendConfig) {
+        this.backendConfig = backendConfig;
+        return this;
     }
 
     Map<String, ByteBuffer> attachedBuffers() {
@@ -58,16 +68,6 @@ public class ModelRunnerBuilder implements AutoCloseable {
 
         // allow the attached buffers to GC its allocated memory
         attachedBuffers.clear();
-    }
-
-    public ModelRunnerBuilder backendName(String backendName) {
-        this.backendName = backendName;
-        return this;
-    }
-
-    public ModelRunnerBuilder backendConfig(String backendConfig) {
-        this.backendConfig = backendConfig;
-        return this;
     }
 
     /**
@@ -153,6 +153,12 @@ public class ModelRunnerBuilder implements AutoCloseable {
         return this;
     }
 
+    /**
+     * <p>Builds a {@link ModelRunner} to <code>run()</code> by using the specified backend (e.g. "mkldnn").</p>
+     *
+     * <p>Menoh will allocate a new buffer for input and output variables to which an external buffer is not
+     * attached. It can be accessed via {@link Model#variable(String)} in the <code>ModelRunner</code> object.</p>
+     */
     public ModelRunner build() {
         try (
                 VariableProfileTable vpt = vptBuilder.build(modelData);

--- a/menoh/src/main/java/jp/preferred/menoh/ModelRunnerBuilder.java
+++ b/menoh/src/main/java/jp/preferred/menoh/ModelRunnerBuilder.java
@@ -2,7 +2,6 @@ package jp.preferred.menoh;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -67,7 +66,7 @@ public class ModelRunnerBuilder implements AutoCloseable {
         vptBuilder.close();
         modelData.close();
 
-        // allow the attached buffers to GC its allocated memory
+        // allow the attached external buffers to GC its allocated memory
         externalBuffers.clear();
     }
 
@@ -109,7 +108,7 @@ public class ModelRunnerBuilder implements AutoCloseable {
      *
      * @throws IllegalArgumentException if <code>buffer</code> is null or empty
      */
-    public ModelRunnerBuilder attach(String variableName, ByteBuffer buffer) throws MenohException {
+    public ModelRunnerBuilder attachExternalBuffer(String variableName, ByteBuffer buffer) throws MenohException {
         externalBuffers.put(variableName, buffer);
         return this;
     }
@@ -126,8 +125,8 @@ public class ModelRunnerBuilder implements AutoCloseable {
      *
      * @throws IllegalArgumentException if <code>values</code> is null or empty
      */
-    public ModelRunnerBuilder attach(String variableName, float[] values) throws MenohException {
-        return attach(variableName, values, 0, values.length);
+    public ModelRunnerBuilder attachExternalBuffer(String variableName, float[] values) throws MenohException {
+        return attachExternalBuffer(variableName, values, 0, values.length);
     }
 
     /**
@@ -145,7 +144,7 @@ public class ModelRunnerBuilder implements AutoCloseable {
      *
      * @throws IllegalArgumentException if <code>values</code> is null or empty
      */
-    public ModelRunnerBuilder attach(
+    public ModelRunnerBuilder attachExternalBuffer(
             String variableName,
             float[] values,
             int offset,
@@ -170,7 +169,7 @@ public class ModelRunnerBuilder implements AutoCloseable {
                 ModelBuilder modelBuilder = Model.builder(vpt)
         ) {
             for (Map.Entry<String, ByteBuffer> e : externalBuffers.entrySet()) {
-                modelBuilder.attach(e.getKey(), e.getValue());
+                modelBuilder.attachExternalBuffer(e.getKey(), e.getValue());
             }
 
             // reduce the memory footprint of

--- a/menoh/src/main/java/jp/preferred/menoh/ModelRunnerBuilder.java
+++ b/menoh/src/main/java/jp/preferred/menoh/ModelRunnerBuilder.java
@@ -31,6 +31,26 @@ public class ModelRunnerBuilder implements AutoCloseable {
         this.attachedBuffers = attachedBuffers;
     }
 
+    ModelData modelData() {
+        return this.modelData;
+    }
+
+    VariableProfileTableBuilder vptBuilder() {
+        return this.vptBuilder;
+    }
+
+    String backendName() {
+        return this.backendName;
+    }
+
+    String backendConfig() {
+        return this.backendConfig;
+    }
+
+    Map<String, ByteBuffer> attachedBuffers() {
+        return this.attachedBuffers;
+    }
+
     @Override
     public void close() {
         vptBuilder.close();

--- a/menoh/src/main/java/jp/preferred/menoh/Variable.java
+++ b/menoh/src/main/java/jp/preferred/menoh/Variable.java
@@ -37,10 +37,19 @@ public class Variable {
     }
 
     /**
-     * The length of buffer.
+     * A direct {@link ByteBuffer} which points to the native buffer of the variable. The buffer can be read
+     * and written via the methods of <code>ByteBuffer</code> before and after running the model.
      */
-    long length() {
+    public ByteBuffer buffer() throws MenohException {
+        return this.bufferHandle.getByteBuffer(0, bufferLength());
+    }
+
+    /**
+     * The length of the buffer in bytes.
+     */
+    long bufferLength() {
         if (dims.length > 0) {
+            final long elementSize = dtype.size();
             long length = 1;
             for (int d : dims) {
                 length *= d;
@@ -50,21 +59,9 @@ public class Variable {
                 throw new MenohException(ErrorCode.UNDEFINED, "buffer is empty");
             }
 
-            return length;
+            return elementSize * length;
         } else {
             throw new MenohException(ErrorCode.UNDEFINED, "buffer is empty");
         }
-    }
-
-    /**
-     * A direct {@link ByteBuffer} which points to the native buffer of the variable. The buffer can be read
-     * and written via the methods of <code>ByteBuffer</code> before and after running the model.
-     */
-    public ByteBuffer buffer() throws MenohException {
-        final long offset = 0;
-        final long elementSize = dtype.size();
-        final long totalLength = elementSize * this.length();
-
-        return this.bufferHandle.getByteBuffer(offset, totalLength);
     }
 }

--- a/menoh/src/main/java/jp/preferred/menoh/Variable.java
+++ b/menoh/src/main/java/jp/preferred/menoh/Variable.java
@@ -39,7 +39,7 @@ public class Variable {
     /**
      * The length of buffer.
      */
-    public long length() {
+    long length() {
         if (dims.length > 0) {
             long length = 1;
             for (int d : dims) {

--- a/menoh/src/test/java/jp/preferred/menoh/ModelDataTest.java
+++ b/menoh/src/test/java/jp/preferred/menoh/ModelDataTest.java
@@ -12,7 +12,7 @@ public class ModelDataTest {
     public void makeFromValidOnnxFile() throws Exception {
         final String path = getResourceFilePath("models/and_op.onnx");
 
-        try (ModelData modelData = ModelData.makeFromOnnx(path)) {
+        try (ModelData modelData = ModelData.fromOnnxFile(path)) {
             assertNotNull(modelData.nativeHandle());
         }
     }
@@ -21,7 +21,7 @@ public class ModelDataTest {
     public void closeModelData() throws Exception {
         final String path = getResourceFilePath("models/and_op.onnx");
 
-        final ModelData modelData = ModelData.makeFromOnnx(path);
+        final ModelData modelData = ModelData.fromOnnxFile(path);
         try {
             assertNotNull(modelData.nativeHandle());
         } finally {
@@ -36,7 +36,7 @@ public class ModelDataTest {
     @Test
     public void makeFromNonExistentOnnxFile() {
         MenohException e = assertThrows(
-                MenohException.class, () -> ModelData.makeFromOnnx("__NON_EXISTENT_FILENAME__"));
+                MenohException.class, () -> ModelData.fromOnnxFile("__NON_EXISTENT_FILENAME__"));
         assertAll("non-existent onnx file",
                 () -> assertEquals(ErrorCode.INVALID_FILENAME, e.getErrorCode()),
                 () -> assertEquals(
@@ -49,7 +49,7 @@ public class ModelDataTest {
     public void makeFromInvalidOnnxFile() throws Exception {
         final String path = getResourceFilePath("models/invalid_format.onnx");
 
-        MenohException e = assertThrows(MenohException.class, () -> ModelData.makeFromOnnx(path));
+        MenohException e = assertThrows(MenohException.class, () -> ModelData.fromOnnxFile(path));
         assertAll("invalid onnx file",
                 () -> assertEquals(ErrorCode.ONNX_PARSE_ERROR, e.getErrorCode()),
                 () -> assertEquals(
@@ -63,7 +63,7 @@ public class ModelDataTest {
         // Note: This file is a copy of and_op.onnx which is edited the last byte to 127 (0x7e)
         final String path = getResourceFilePath("models/unsupported_onnx_opset_version.onnx");
 
-        MenohException e = assertThrows(MenohException.class, () -> ModelData.makeFromOnnx(path));
+        MenohException e = assertThrows(MenohException.class, () -> ModelData.fromOnnxFile(path));
         assertAll("invalid onnx file",
                 () -> assertEquals(ErrorCode.UNSUPPORTED_ONNX_OPSET_VERSION, e.getErrorCode()),
                 () -> assertEquals(
@@ -80,7 +80,7 @@ public class ModelDataTest {
         final String path = getResourceFilePath("models/and_op.onnx");
 
         try (
-                ModelData modelData = ModelData.makeFromOnnx(path);
+                ModelData modelData = ModelData.fromOnnxFile(path);
                 VariableProfileTableBuilder vptBuilder = VariableProfileTable.builder()
                         .addInputProfile("input", DType.FLOAT, new int[] {1, 2})
                         .addOutputProfile("output", DType.FLOAT);

--- a/menoh/src/test/java/jp/preferred/menoh/ModelRunnerTest.java
+++ b/menoh/src/test/java/jp/preferred/menoh/ModelRunnerTest.java
@@ -42,8 +42,8 @@ public class ModelRunnerTest {
                     () -> assertEquals("", builder.backendConfig())
             );
             assertAll("attached buffers in builder",
-                    () -> assertNotNull(builder.attachedBuffers()),
-                    () -> assertNotNull(builder.attachedBuffers().get("input"))
+                    () -> assertNotNull(builder.externalBuffers()),
+                    () -> assertNotNull(builder.externalBuffers().get("input"))
             );
 
             assertAll("model in runner",
@@ -108,8 +108,8 @@ public class ModelRunnerTest {
                     () -> assertEquals("", builder.backendConfig())
             );
             assertAll("attached buffers in builder",
-                    () -> assertNotNull(builder.attachedBuffers()),
-                    () -> assertNotNull(builder.attachedBuffers().get("input"))
+                    () -> assertNotNull(builder.externalBuffers()),
+                    () -> assertNotNull(builder.externalBuffers().get("input"))
             );
 
             assertNotNull(runner);
@@ -128,9 +128,9 @@ public class ModelRunnerTest {
                     () -> assertNull(builder.vptBuilder().nativeHandle())
             );
             assertAll("attached buffers in builder",
-                    () -> assertNotNull(builder.attachedBuffers()),
-                    () -> assertTrue(builder.attachedBuffers().isEmpty(),
-                            "attachedBuffers should be empty")
+                    () -> assertNotNull(builder.externalBuffers()),
+                    () -> assertTrue(builder.externalBuffers().isEmpty(),
+                            "externalBuffers should be empty")
             );
 
             runner.close();

--- a/menoh/src/test/java/jp/preferred/menoh/ModelRunnerTest.java
+++ b/menoh/src/test/java/jp/preferred/menoh/ModelRunnerTest.java
@@ -24,7 +24,7 @@ public class ModelRunnerTest {
                         .fromOnnxFile(path)
                         .addInputProfile("input", DType.FLOAT, new int[] {batchSize, inputDim})
                         .addOutputProfile("output", DType.FLOAT)
-                        .attach("input", inputData1)
+                        .attachExternalBuffer("input", inputData1)
                         .backendName("mkldnn")
                         .backendConfig("");
                  ModelRunner runner = builder.build()
@@ -41,7 +41,7 @@ public class ModelRunnerTest {
                     () -> assertEquals("mkldnn", builder.backendName()),
                     () -> assertEquals("", builder.backendConfig())
             );
-            assertAll("attached buffers in builder",
+            assertAll("attached external buffers in builder",
                     () -> assertNotNull(builder.externalBuffers()),
                     () -> assertNotNull(builder.externalBuffers().get("input"))
             );
@@ -89,7 +89,7 @@ public class ModelRunnerTest {
                 .fromOnnxFile(path)
                 .addInputProfile("input", DType.FLOAT, new int[] {batchSize, inputDim})
                 .addOutputProfile("output", DType.FLOAT)
-                .attach("input", inputData)
+                .attachExternalBuffer("input", inputData)
                 .backendName("mkldnn")
                 .backendConfig("");
         final ModelRunner runner = builder.build();
@@ -107,7 +107,7 @@ public class ModelRunnerTest {
                     () -> assertEquals("mkldnn", builder.backendName()),
                     () -> assertEquals("", builder.backendConfig())
             );
-            assertAll("attached buffers in builder",
+            assertAll("attached external buffers in builder",
                     () -> assertNotNull(builder.externalBuffers()),
                     () -> assertNotNull(builder.externalBuffers().get("input"))
             );
@@ -127,7 +127,7 @@ public class ModelRunnerTest {
                     () -> assertNotNull(builder.vptBuilder()),
                     () -> assertNull(builder.vptBuilder().nativeHandle())
             );
-            assertAll("attached buffers in builder",
+            assertAll("attached external buffers in builder",
                     () -> assertNotNull(builder.externalBuffers()),
                     () -> assertTrue(builder.externalBuffers().isEmpty(),
                             "externalBuffers should be empty")

--- a/menoh/src/test/java/jp/preferred/menoh/ModelRunnerTest.java
+++ b/menoh/src/test/java/jp/preferred/menoh/ModelRunnerTest.java
@@ -1,0 +1,138 @@
+package jp.preferred.menoh;
+
+// CHECKSTYLE:OFF
+import static jp.preferred.menoh.TestUtils.*;
+import static org.junit.jupiter.api.Assertions.*;
+// CHECKSTYLE:ON
+
+import org.junit.jupiter.api.Test;
+
+public class ModelRunnerTest {
+    @Test
+    public void runModelRunner() throws Exception {
+        final String path = getResourceFilePath("models/and_op.onnx");
+        final int batchSize = 4;
+        final int inputDim = 2;
+        final float[] inputData1 = new float[] {0f, 0f, 0f, 1f, 1f, 0f, 1f, 1f};
+        final float[] inputData2 = new float[] {1f, 1f, 1f, 0f, 0f, 1f, 0f, 0f};
+        final int outputDim = 1;
+        final float[] expectedOutput1 = new float[] {0f, 0f, 0f, 1f};
+        final float[] expectedOutput2 = new float[] {1f, 0f, 0f, 0f};
+
+        try (ModelRunner runner = ModelRunner
+                .fromOnnxFile(path)
+                .addInputProfile("input", DType.FLOAT, new int[] {batchSize, inputDim})
+                .addOutputProfile("output", DType.FLOAT)
+                .attach("input", inputData1)
+                .backendName("mkldnn")
+                .backendConfig("")
+                .build()) {
+
+            assertAll("model",
+                    () -> assertNotNull(runner.model()),
+                    () -> assertNotNull(runner.model().nativeHandle())
+            );
+            assertNotNull(runner.builder());
+            assertAll("model data in builder",
+                    () -> assertNotNull(runner.builder().modelData()),
+                    () -> assertNull(runner.builder().modelData().nativeHandle()) // deleted in build()
+            );
+            assertAll("vpt builder in builder",
+                    () -> assertNotNull(runner.builder().vptBuilder()),
+                    () -> assertNotNull(runner.builder().vptBuilder().nativeHandle())
+            );
+            assertAll("backend config in builder",
+                    () -> assertEquals("mkldnn", runner.builder().backendName()),
+                    () -> assertEquals("", runner.builder().backendConfig())
+            );
+            assertAll("attached buffers in builder",
+                    () -> assertNotNull(runner.builder().attachedBuffers()),
+                    () -> assertNotNull(runner.builder().attachedBuffers().get("input"))
+            );
+
+            // run the model
+            runner.run();
+
+            final Model model = runner.model();
+            final Variable outputVar = model.variable("output");
+            assertAll("output variable",
+                    () -> assertEquals(DType.FLOAT, outputVar.dtype()),
+                    () -> assertArrayEquals(new int[] {batchSize, outputDim}, outputVar.dims())
+            );
+            final float[] outputBuf = new float[outputVar.dims()[0]];
+            outputVar.buffer().asFloatBuffer().get(outputBuf);
+            assertArrayEquals(expectedOutput1, outputBuf);
+
+            // rewrite the internal buffer and run again
+            runner.run("input", inputData2);
+
+            final Variable outputVar2 = model.variable("output");
+            assertAll("output variable",
+                    () -> assertEquals(DType.FLOAT, outputVar2.dtype()),
+                    () -> assertArrayEquals(new int[] {batchSize, outputDim}, outputVar2.dims())
+            );
+            final float[] outputBuf2 = new float[outputVar2.dims()[0]];
+            outputVar.buffer().asFloatBuffer().get(outputBuf2);
+            assertArrayEquals(expectedOutput2, outputBuf2);
+        }
+    }
+
+    @Test
+    public void closeModelRunner() throws Exception {
+        final String path = getResourceFilePath("models/and_op.onnx");
+        final int batchSize = 4;
+        final int inputDim = 2;
+        final float[] inputData = new float[] {0f, 0f, 0f, 1f, 1f, 0f, 1f, 1f};
+
+        final ModelRunner runner = ModelRunner
+                .fromOnnxFile(path)
+                .addInputProfile("input", DType.FLOAT, new int[] {batchSize, inputDim})
+                .addOutputProfile("output", DType.FLOAT)
+                .attach("input", inputData)
+                .backendName("mkldnn")
+                .backendConfig("")
+                .build();
+        try {
+            assertAll("model",
+                    () -> assertNotNull(runner.model()),
+                    () -> assertNotNull(runner.model().nativeHandle())
+            );
+            assertNotNull(runner.builder());
+            assertAll("model data in builder",
+                    () -> assertNotNull(runner.builder().modelData()),
+                    () -> assertNull(runner.builder().modelData().nativeHandle()) // deleted in build()
+            );
+            assertAll("vpt builder in builder",
+                    () -> assertNotNull(runner.builder().vptBuilder()),
+                    () -> assertNotNull(runner.builder().vptBuilder().nativeHandle())
+            );
+            assertAll("backend config in builder",
+                    () -> assertEquals("mkldnn", runner.builder().backendName()),
+                    () -> assertEquals("", runner.builder().backendConfig())
+            );
+            assertAll("attached buffers in builder",
+                    () -> assertNotNull(runner.builder().attachedBuffers()),
+                    () -> assertNotNull(runner.builder().attachedBuffers().get("input"))
+            );
+        } finally {
+            runner.close();
+            assertAll("model",
+                    () -> assertNotNull(runner.model()),
+                    () -> assertNull(runner.model().nativeHandle())
+            );
+            assertNotNull(runner.builder());
+            assertAll("vpt builder in builder",
+                    () -> assertNotNull(runner.builder().vptBuilder()),
+                    () -> assertNull(runner.builder().vptBuilder().nativeHandle())
+            );
+            assertAll("attached buffers in builder",
+                    () -> assertNotNull(runner.builder().attachedBuffers()),
+                    () -> assertTrue(runner.builder().attachedBuffers().isEmpty(),
+                            "attachedBuffers should be empty")
+            );
+
+            // close() is an idempotent operation
+            runner.close();
+        }
+    }
+}

--- a/menoh/src/test/java/jp/preferred/menoh/ModelTest.java
+++ b/menoh/src/test/java/jp/preferred/menoh/ModelTest.java
@@ -26,7 +26,7 @@ public class ModelTest {
                 VariableProfileTable vpt = vptBuilder.build(modelData);
                 ModelBuilder modelBuilder = Model.builder(vpt)
         ) {
-            modelBuilder.attach("input", inputData);
+            modelBuilder.attachExternalBuffer("input", inputData);
 
             assertAll("model builder",
                     () -> assertNotNull(modelBuilder.nativeHandle()),
@@ -53,7 +53,7 @@ public class ModelTest {
         ) {
             final ModelBuilder modelBuilder = Model.builder(vpt);
             try {
-                modelBuilder.attach("input", inputData);
+                modelBuilder.attachExternalBuffer("input", inputData);
 
                 assertAll("model builder",
                         () -> assertNotNull(modelBuilder.nativeHandle()),
@@ -92,15 +92,15 @@ public class ModelTest {
                 VariableProfileTable vpt = vptBuilder.build(modelData);
                 ModelBuilder modelBuilder = Model.builder(vpt)
         ) {
-            modelBuilder.attach("input", new float[] {0f, 0f, 0f, 1f, 1f, 0f, 1f, 1f});
+            modelBuilder.attachExternalBuffer("input", new float[] {0f, 0f, 0f, 1f, 1f, 0f, 1f, 1f});
             assertTrue(!modelBuilder.externalBuffers().isEmpty(), "externalBuffers should not be empty");
 
             try (Model model = modelBuilder.build(modelData, backendName, backendConfig)) {
                 assertAll("model",
                         () -> assertNotNull(model.nativeHandle()),
-                        () -> assertNotNull(model.attachedBuffers()),
+                        () -> assertNotNull(model.externalBuffers()),
                         () -> assertArrayEquals(
-                                modelBuilder.externalBuffers().toArray(), model.attachedBuffers().toArray())
+                                modelBuilder.externalBuffers().toArray(), model.externalBuffers().toArray())
                 );
             }
         }
@@ -123,23 +123,23 @@ public class ModelTest {
                 VariableProfileTable vpt = vptBuilder.build(modelData);
                 ModelBuilder modelBuilder = Model.builder(vpt)
         ) {
-            modelBuilder.attach("input", input);
+            modelBuilder.attachExternalBuffer("input", input);
             assertTrue(!modelBuilder.externalBuffers().isEmpty(), "externalBuffers should not be empty");
 
             final Model model = modelBuilder.build(modelData, backendName, backendConfig);
             try {
                 assertAll("model",
                         () -> assertNotNull(model.nativeHandle()),
-                        () -> assertNotNull(model.attachedBuffers()),
+                        () -> assertNotNull(model.externalBuffers()),
                         () -> assertArrayEquals(
-                                modelBuilder.externalBuffers().toArray(), model.attachedBuffers().toArray())
+                                modelBuilder.externalBuffers().toArray(), model.externalBuffers().toArray())
                 );
             } finally {
                 model.close();
                 assertAll("model",
                         () -> assertNull(model.nativeHandle()),
-                        () -> assertNotNull(model.attachedBuffers()),
-                        () -> assertTrue(model.attachedBuffers().isEmpty(), "externalBuffers should be empty")
+                        () -> assertNotNull(model.externalBuffers()),
+                        () -> assertTrue(model.externalBuffers().isEmpty(), "externalBuffers should be empty")
                 );
                 assertAll("model builder",
                         () -> assertNotNull(modelBuilder.externalBuffers()),
@@ -170,7 +170,7 @@ public class ModelTest {
                 VariableProfileTable vpt = vptBuilder.build(modelData)
         ) {
             try (ModelBuilder modelBuilder = Model.builder(vpt)) {
-                modelBuilder.attach("input", input);
+                modelBuilder.attachExternalBuffer("input", input);
                 assertTrue(!modelBuilder.externalBuffers().isEmpty(), "externalBuffers should not be empty");
 
                 final Model model = modelBuilder.build(modelData, backendName, backendConfig);
@@ -185,8 +185,8 @@ public class ModelTest {
                     );
                     assertAll("model",
                             () -> assertNotNull(model.nativeHandle()),
-                            () -> assertNotNull(model.attachedBuffers()),
-                            () -> assertTrue(!model.attachedBuffers().isEmpty(),
+                            () -> assertNotNull(model.externalBuffers()),
+                            () -> assertTrue(!model.externalBuffers().isEmpty(),
                                     "externalBuffers should not be empty")
                     );
                 } finally {
@@ -212,7 +212,7 @@ public class ModelTest {
                 VariableProfileTable vpt = vptBuilder.build(modelData);
                 ModelBuilder modelBuilder = Model.builder(vpt)
         ) {
-            modelBuilder.attach("input", new float[] {0f, 0f, 0f, 1f, 1f, 0f, 1f, 1f});
+            modelBuilder.attachExternalBuffer("input", new float[] {0f, 0f, 0f, 1f, 1f, 0f, 1f, 1f});
 
             MenohException e = assertThrows(
                     MenohException.class, () -> modelBuilder.build(modelData, backendName, backendConfig));
@@ -304,7 +304,8 @@ public class ModelTest {
                         .addInputProfile("input", DType.FLOAT, new int[] {batchSize, inputDim})
                         .addOutputProfile("output", DType.FLOAT);
                 VariableProfileTable vpt = vptBuilder.build(modelData);
-                ModelBuilder modelBuilder = Model.builder(vpt).attach("input", inputDataBuf);
+                ModelBuilder modelBuilder =
+                        Model.builder(vpt).attachExternalBuffer("input", inputDataBuf);
                 Model model = modelBuilder.build(modelData, "mkldnn", "")
         ) {
             // you can delete modelData explicitly after building a model
@@ -366,7 +367,8 @@ public class ModelTest {
                         .addInputProfile("input", DType.FLOAT, new int[] {batchSize, inputDim})
                         .addOutputProfile("output", DType.FLOAT);
                 VariableProfileTable vpt = vptBuilder.build(modelData);
-                ModelBuilder modelBuilder = Model.builder(vpt).attach("input", inputDataBuf);
+                ModelBuilder modelBuilder =
+                        Model.builder(vpt).attachExternalBuffer("input", inputDataBuf);
                 Model model = modelBuilder.build(modelData, "mkldnn", "")
         ) {
             // you can delete modelData explicitly after building a model
@@ -415,7 +417,8 @@ public class ModelTest {
                         .addInputProfile("input", DType.FLOAT, new int[] {batchSize, inputDim})
                         .addOutputProfile("output", DType.FLOAT);
                 VariableProfileTable vpt = vptBuilder.build(modelData);
-                ModelBuilder modelBuilder = Model.builder(vpt).attach("input", readOnlyInputDataBuf);
+                ModelBuilder modelBuilder =
+                        Model.builder(vpt).attachExternalBuffer("input", readOnlyInputDataBuf);
                 Model model = modelBuilder.build(modelData, "mkldnn", "")
         ) {
             // you can delete modelData explicitly after building a model
@@ -460,7 +463,8 @@ public class ModelTest {
                         .addInputProfile("input", DType.FLOAT, new int[] {batchSize, inputDim})
                         .addOutputProfile("output", DType.FLOAT);
                 VariableProfileTable vpt = vptBuilder.build(modelData);
-                ModelBuilder modelBuilder = Model.builder(vpt).attach("input", inputData);
+                ModelBuilder modelBuilder =
+                        Model.builder(vpt).attachExternalBuffer("input", inputData);
                 Model model = modelBuilder.build(modelData, "mkldnn", "")
         ) {
             // you can delete modelData explicitly after building a model

--- a/menoh/src/test/java/jp/preferred/menoh/ModelTest.java
+++ b/menoh/src/test/java/jp/preferred/menoh/ModelTest.java
@@ -30,9 +30,9 @@ public class ModelTest {
 
             assertAll("model builder",
                     () -> assertNotNull(modelBuilder.nativeHandle()),
-                    () -> assertNotNull(modelBuilder.attachedBuffers()),
-                    () -> assertTrue(!modelBuilder.attachedBuffers().isEmpty(),
-                            "attachedBuffers should not be empty")
+                    () -> assertNotNull(modelBuilder.externalBuffers()),
+                    () -> assertTrue(!modelBuilder.externalBuffers().isEmpty(),
+                            "externalBuffers should not be empty")
             );
         }
     }
@@ -57,17 +57,17 @@ public class ModelTest {
 
                 assertAll("model builder",
                         () -> assertNotNull(modelBuilder.nativeHandle()),
-                        () -> assertNotNull(modelBuilder.attachedBuffers()),
-                        () -> assertTrue(!modelBuilder.attachedBuffers().isEmpty(),
-                                "attachedBuffers should not be empty")
+                        () -> assertNotNull(modelBuilder.externalBuffers()),
+                        () -> assertTrue(!modelBuilder.externalBuffers().isEmpty(),
+                                "externalBuffers should not be empty")
                 );
             } finally {
                 modelBuilder.close();
                 assertAll("model builder",
                         () -> assertNull(modelBuilder.nativeHandle()),
-                        () -> assertNotNull(modelBuilder.attachedBuffers()),
-                        () -> assertTrue(modelBuilder.attachedBuffers().isEmpty(),
-                                "attachedBuffers should be empty")
+                        () -> assertNotNull(modelBuilder.externalBuffers()),
+                        () -> assertTrue(modelBuilder.externalBuffers().isEmpty(),
+                                "externalBuffers should be empty")
                 );
 
                 // close() is an idempotent operation
@@ -93,14 +93,14 @@ public class ModelTest {
                 ModelBuilder modelBuilder = Model.builder(vpt)
         ) {
             modelBuilder.attach("input", new float[] {0f, 0f, 0f, 1f, 1f, 0f, 1f, 1f});
-            assertTrue(!modelBuilder.attachedBuffers().isEmpty(), "attachedBuffers should not be empty");
+            assertTrue(!modelBuilder.externalBuffers().isEmpty(), "externalBuffers should not be empty");
 
             try (Model model = modelBuilder.build(modelData, backendName, backendConfig)) {
                 assertAll("model",
                         () -> assertNotNull(model.nativeHandle()),
                         () -> assertNotNull(model.attachedBuffers()),
                         () -> assertArrayEquals(
-                                modelBuilder.attachedBuffers().toArray(), model.attachedBuffers().toArray())
+                                modelBuilder.externalBuffers().toArray(), model.attachedBuffers().toArray())
                 );
             }
         }
@@ -124,7 +124,7 @@ public class ModelTest {
                 ModelBuilder modelBuilder = Model.builder(vpt)
         ) {
             modelBuilder.attach("input", input);
-            assertTrue(!modelBuilder.attachedBuffers().isEmpty(), "attachedBuffers should not be empty");
+            assertTrue(!modelBuilder.externalBuffers().isEmpty(), "externalBuffers should not be empty");
 
             final Model model = modelBuilder.build(modelData, backendName, backendConfig);
             try {
@@ -132,19 +132,19 @@ public class ModelTest {
                         () -> assertNotNull(model.nativeHandle()),
                         () -> assertNotNull(model.attachedBuffers()),
                         () -> assertArrayEquals(
-                                modelBuilder.attachedBuffers().toArray(), model.attachedBuffers().toArray())
+                                modelBuilder.externalBuffers().toArray(), model.attachedBuffers().toArray())
                 );
             } finally {
                 model.close();
                 assertAll("model",
                         () -> assertNull(model.nativeHandle()),
                         () -> assertNotNull(model.attachedBuffers()),
-                        () -> assertTrue(model.attachedBuffers().isEmpty(), "attachedBuffers should be empty")
+                        () -> assertTrue(model.attachedBuffers().isEmpty(), "externalBuffers should be empty")
                 );
                 assertAll("model builder",
-                        () -> assertNotNull(modelBuilder.attachedBuffers()),
-                        () -> assertTrue(!modelBuilder.attachedBuffers().isEmpty(),
-                                "attachedBuffers should not be empty")
+                        () -> assertNotNull(modelBuilder.externalBuffers()),
+                        () -> assertTrue(!modelBuilder.externalBuffers().isEmpty(),
+                                "externalBuffers should not be empty")
                 );
 
                 // close() is an idempotent operation
@@ -171,7 +171,7 @@ public class ModelTest {
         ) {
             try (ModelBuilder modelBuilder = Model.builder(vpt)) {
                 modelBuilder.attach("input", input);
-                assertTrue(!modelBuilder.attachedBuffers().isEmpty(), "attachedBuffers should not be empty");
+                assertTrue(!modelBuilder.externalBuffers().isEmpty(), "externalBuffers should not be empty");
 
                 final Model model = modelBuilder.build(modelData, backendName, backendConfig);
                 try {
@@ -179,15 +179,15 @@ public class ModelTest {
                     modelBuilder.close();
 
                     assertAll("model builder",
-                            () -> assertNotNull(modelBuilder.attachedBuffers()),
-                            () -> assertTrue(modelBuilder.attachedBuffers().isEmpty(),
-                                    "attachedBuffers should be empty")
+                            () -> assertNotNull(modelBuilder.externalBuffers()),
+                            () -> assertTrue(modelBuilder.externalBuffers().isEmpty(),
+                                    "externalBuffers should be empty")
                     );
                     assertAll("model",
                             () -> assertNotNull(model.nativeHandle()),
                             () -> assertNotNull(model.attachedBuffers()),
                             () -> assertTrue(!model.attachedBuffers().isEmpty(),
-                                    "attachedBuffers should not be empty")
+                                    "externalBuffers should not be empty")
                     );
                 } finally {
                     model.close();

--- a/menoh/src/test/java/jp/preferred/menoh/ModelTest.java
+++ b/menoh/src/test/java/jp/preferred/menoh/ModelTest.java
@@ -19,7 +19,7 @@ public class ModelTest {
         final float[] inputData = new float[] {0f, 0f, 0f, 1f, 1f, 0f, 1f, 1f};
 
         try (
-                ModelData modelData = ModelData.makeFromOnnx(path);
+                ModelData modelData = ModelData.fromOnnxFile(path);
                 VariableProfileTableBuilder vptBuilder = VariableProfileTable.builder()
                         .addInputProfile("input", DType.FLOAT, new int[] {batchSize, inputDim})
                         .addOutputProfile("output", DType.FLOAT);
@@ -45,7 +45,7 @@ public class ModelTest {
         final float[] inputData = new float[] {0f, 0f, 0f, 1f, 1f, 0f, 1f, 1f};
 
         try (
-                ModelData modelData = ModelData.makeFromOnnx(path);
+                ModelData modelData = ModelData.fromOnnxFile(path);
                 VariableProfileTableBuilder vptBuilder = VariableProfileTable.builder()
                         .addInputProfile("input", DType.FLOAT, new int[] {batchSize, inputDim})
                         .addOutputProfile("output", DType.FLOAT);
@@ -85,7 +85,7 @@ public class ModelTest {
         final String backendConfig = "";
 
         try (
-                ModelData modelData = ModelData.makeFromOnnx(path);
+                ModelData modelData = ModelData.fromOnnxFile(path);
                 VariableProfileTableBuilder vptBuilder = VariableProfileTable.builder()
                         .addInputProfile("input", DType.FLOAT, new int[] {batchSize, inputDim})
                         .addOutputProfile("output", DType.FLOAT);
@@ -116,7 +116,7 @@ public class ModelTest {
         final String backendConfig = "";
 
         try (
-                ModelData modelData = ModelData.makeFromOnnx(path);
+                ModelData modelData = ModelData.fromOnnxFile(path);
                 VariableProfileTableBuilder vptBuilder = VariableProfileTable.builder()
                         .addInputProfile("input", DType.FLOAT, new int[] {batchSize, inputDim})
                         .addOutputProfile("output", DType.FLOAT);
@@ -163,7 +163,7 @@ public class ModelTest {
         final String backendConfig = "";
 
         try (
-                ModelData modelData = ModelData.makeFromOnnx(path);
+                ModelData modelData = ModelData.fromOnnxFile(path);
                 VariableProfileTableBuilder vptBuilder = VariableProfileTable.builder()
                         .addInputProfile("input", DType.FLOAT, new int[] {batchSize, inputDim})
                         .addOutputProfile("output", DType.FLOAT);
@@ -205,7 +205,7 @@ public class ModelTest {
         final String backendConfig = "";
 
         try (
-                ModelData modelData = ModelData.makeFromOnnx(path);
+                ModelData modelData = ModelData.fromOnnxFile(path);
                 VariableProfileTableBuilder vptBuilder = VariableProfileTable.builder()
                         .addInputProfile("input", DType.FLOAT, new int[] {batchSize, inputDim})
                         .addOutputProfile("output", DType.FLOAT);
@@ -238,7 +238,7 @@ public class ModelTest {
         final float[] expectedOutput2 = new float[] {1f, 0f, 0f, 0f};
 
         try (
-                ModelData modelData = ModelData.makeFromOnnx(path);
+                ModelData modelData = ModelData.fromOnnxFile(path);
                 VariableProfileTableBuilder vptBuilder = VariableProfileTable.builder()
                         .addInputProfile("input", DType.FLOAT, new int[] {batchSize, inputDim})
                         .addOutputProfile("output", DType.FLOAT);
@@ -299,7 +299,7 @@ public class ModelTest {
         final float[] expectedOutput2 = new float[] {1f, 0f, 0f, 0f};
 
         try (
-                ModelData modelData = ModelData.makeFromOnnx(path);
+                ModelData modelData = ModelData.fromOnnxFile(path);
                 VariableProfileTableBuilder vptBuilder = VariableProfileTable.builder()
                         .addInputProfile("input", DType.FLOAT, new int[] {batchSize, inputDim})
                         .addOutputProfile("output", DType.FLOAT);
@@ -361,7 +361,7 @@ public class ModelTest {
         final float[] expectedOutput = new float[] {0f, 0f, 0f, 1f};
 
         try (
-                ModelData modelData = ModelData.makeFromOnnx(path);
+                ModelData modelData = ModelData.fromOnnxFile(path);
                 VariableProfileTableBuilder vptBuilder = VariableProfileTable.builder()
                         .addInputProfile("input", DType.FLOAT, new int[] {batchSize, inputDim})
                         .addOutputProfile("output", DType.FLOAT);
@@ -410,7 +410,7 @@ public class ModelTest {
         final float[] expectedOutput = new float[] {0f, 0f, 0f, 1f};
 
         try (
-                ModelData modelData = ModelData.makeFromOnnx(path);
+                ModelData modelData = ModelData.fromOnnxFile(path);
                 VariableProfileTableBuilder vptBuilder = VariableProfileTable.builder()
                         .addInputProfile("input", DType.FLOAT, new int[] {batchSize, inputDim})
                         .addOutputProfile("output", DType.FLOAT);
@@ -455,7 +455,7 @@ public class ModelTest {
         final float[] expectedOutput = new float[] {0f, 0f, 0f, 1f};
 
         try (
-                ModelData modelData = ModelData.makeFromOnnx(path);
+                ModelData modelData = ModelData.fromOnnxFile(path);
                 VariableProfileTableBuilder vptBuilder = VariableProfileTable.builder()
                         .addInputProfile("input", DType.FLOAT, new int[] {batchSize, inputDim})
                         .addOutputProfile("output", DType.FLOAT);

--- a/menoh/src/test/java/jp/preferred/menoh/VariableProfileTableTest.java
+++ b/menoh/src/test/java/jp/preferred/menoh/VariableProfileTableTest.java
@@ -58,7 +58,7 @@ public class VariableProfileTableTest {
         final int outputDim = 1;
 
         try (
-                ModelData modelData = ModelData.makeFromOnnx(path);
+                ModelData modelData = ModelData.fromOnnxFile(path);
                 VariableProfileTableBuilder vptBuilder = VariableProfileTable.builder()
                         .addInputProfile("input", DType.FLOAT, new int[] {batchSize, inputDim})
                         .addOutputProfile("output", DType.FLOAT);
@@ -88,7 +88,7 @@ public class VariableProfileTableTest {
         final int outputDim = 1;
 
         try (
-                ModelData modelData = ModelData.makeFromOnnx(path);
+                ModelData modelData = ModelData.fromOnnxFile(path);
                 VariableProfileTableBuilder vptBuilder = VariableProfileTable.builder()
                         .addInputProfile("input", DType.FLOAT, new int[] {batchSize, inputDim})
                         .addOutputProfile("output", DType.FLOAT);
@@ -117,7 +117,7 @@ public class VariableProfileTableTest {
         final int inputDim = 2;
 
         try (
-                ModelData modelData = ModelData.makeFromOnnx(path);
+                ModelData modelData = ModelData.fromOnnxFile(path);
                 VariableProfileTableBuilder vptBuilder = VariableProfileTable.builder()
                         .addInputProfile("input", DType.FLOAT, new int[] {batchSize, inputDim})
                         .addOutputProfile("output", DType.FLOAT)
@@ -145,7 +145,7 @@ public class VariableProfileTableTest {
         final String outputProfileName = "output";
 
         try (
-                ModelData modelData = ModelData.makeFromOnnx(path);
+                ModelData modelData = ModelData.fromOnnxFile(path);
                 VariableProfileTableBuilder vptBuilder = VariableProfileTable.builder()
                         .addInputProfile(inputProfileName, DType.FLOAT, new int[] {batchSize, inputDim})
                         .addOutputProfile(outputProfileName, DType.FLOAT)
@@ -170,7 +170,7 @@ public class VariableProfileTableTest {
         final String outputProfileName = "output";
 
         try (
-                ModelData modelData = ModelData.makeFromOnnx(path);
+                ModelData modelData = ModelData.fromOnnxFile(path);
                 VariableProfileTableBuilder vptBuilder = VariableProfileTable.builder()
                         .addInputProfile(inputProfileName, DType.FLOAT, new int[] {batchSize, inputDim})
                         .addOutputProfile(outputProfileName, DType.FLOAT)
@@ -198,7 +198,7 @@ public class VariableProfileTableTest {
         final String outputProfileName = "__non_existent_variable__"; // test case
 
         try (
-                ModelData modelData = ModelData.makeFromOnnx(path);
+                ModelData modelData = ModelData.fromOnnxFile(path);
                 VariableProfileTableBuilder vptBuilder = VariableProfileTable.builder()
                         .addInputProfile(inputProfileName, DType.FLOAT, new int[] {batchSize, inputDim})
                         .addOutputProfile(outputProfileName, DType.FLOAT)


### PR DESCRIPTION
Add `ModelRunner` for providing a convenient wrapper of `Model` and its builder objects. It manages the lifecycle of builders (i.e. invoke `close()` after being finished) on behalf of users.

It also have other variation of `run()` such like `run(Map<String, ByteBuffer>)` and `run(String, float[])`, which enables you to assign data to variables and run the model in one line.

- before:
```java
try (
    ModelData modelData = ModelData.makeFromOnnx(onnxModelPath);
    VariableProfileTableBuilder vptBuilder = VariableProfileTable.builder()
        .addInputProfile(conv11InName, DType.FLOAT, new int[] {batchSize, channelNum, height, width})
        .addOutputProfile(fc6OutName, DType.FLOAT)
        .addOutputProfile(softmaxOutName, DType.FLOAT);
    VariableProfileTable vpt = vptBuilder.build(modelData);
    ModelBuilder modelBuilder = Model.builder(vpt).attach(conv11InName, imageData);
    Model model = modelBuilder.build(modelData, "mkldnn", "")
) {
    // modelData can be deleted explicitly after building a model
    modelData.close();

    model.run();
    ...
}
```

- after:
```java
try (
    ModelRunnerBuilder builder = ModelRunner
        .fromOnnxFile(onnxModelPath)
        .addInputProfile(conv11InName, DType.FLOAT, new int[] {batchSize, channelNum, height, width})
        .addOutputProfile(fc6OutName, DType.FLOAT)
        .addOutputProfile(softmaxOutName, DType.FLOAT)
        .backendName("mkldnn")
        .backendConfig("");
    ModelRunner runner = builder.build()
) {
    // modelRunnerBuilder can be deleted explicitly after building a model
    modelRunnerBuilder.close();

    runner.run(conv11InName, imageData);
    ...
}
```
